### PR TITLE
Add dynarec support for PS3

### DIFF
--- a/Makefile.libretro
+++ b/Makefile.libretro
@@ -188,13 +188,9 @@ else ifneq (,$(filter $(platform), ps3 psl1ght))
 	CFLAGS += -DFAMEC_NO_GOTOS -D__PS3__
 	STATIC_LINKING = 1
 	STATIC_LINKING_LINK = 1
-	NO_MMAP = 1
 	ifeq ($(platform), psl1ght)
 		FLAGS += -D__PSL1GHT__
 	endif
-	# PS3 has memory mapped in a way not suitable for DRC
-	use_sh2drc = 0
-	use_svpdrc = 0
 
 # PSP
 else ifeq ($(platform), psp1)

--- a/cpu/drc/emit_ppc.c
+++ b/cpu/drc/emit_ppc.c
@@ -1507,29 +1507,20 @@ static int emith_cond_check(int cond)
 #define emith_call_cond(cond, target) \
 	emith_call(target)
 
-#ifdef __PS3__
-#define emith_call_reg(r) do { \
-	emith_read_r_r_offs_ptr(TOC_REG, r, 8); \
-	emith_read_r_r_offs_ptr(r, r, 0); \
-	EMIT(PPC_MTSP_REG(r, CTR)); \
-	EMIT(PPC_BLCTRCOND(BXX)); \
-} while(0)
-#else
 #define emith_call_reg(r) do { \
 	EMIT(PPC_MTSP_REG(r, CTR)); \
 	EMIT(PPC_BLCTRCOND(BXX)); \
 } while(0)
-#endif
 
 #define emith_abicall_ctx(offs) do { \
 	emith_ctx_read_ptr(CR, offs); \
-	emith_call_reg(CR); \
+	emith_abicall_reg(CR); \
 } while (0)
 
 #ifdef __PS3__
 #define emith_abijump_reg(r) \
 	if ((r) != CR) emith_move_r_r(CR, r); \
-	emith_read_r_r_offs_ptr(TOC_REG, CR, 8); \
+	emith_read_r_r_offs_ptr(TOC_REG, CR, PTR_SIZE); \
 	emith_read_r_r_offs_ptr(CR, CR, 0); \
 	emith_jump_reg(CR)
 #else
@@ -1541,12 +1532,22 @@ static int emith_cond_check(int cond)
 	emith_abijump_reg(r)
 #define emith_abicall(target) \
 	emith_move_r_ptr_imm(CR, target); \
-	emith_call_reg(CR);
+	emith_abicall_reg(CR);
 #define emith_abicall_cond(cond, target) \
 	emith_abicall(target)
-#define emith_abicall_reg(r) \
+#ifdef __PS3__
+#define emith_abicall_reg(r) do { \
 	if ((r) != CR) emith_move_r_r(CR, r); \
-	emith_call_reg(CR)
+	emith_read_r_r_offs_ptr(TOC_REG, r, PTR_SIZE); \
+	emith_read_r_r_offs_ptr(r, r, 0); \
+	emith_call_reg(CR); \
+} while(0)
+#else
+#define emith_abicall_reg(r) do { \
+	if ((r) != CR) emith_move_r_r(CR, r); \
+	emith_call_reg(CR); \
+} while(0)
+#endif
 
 #define emith_call_cleanup()	/**/
 

--- a/cpu/drc/emit_x86.c
+++ b/cpu/drc/emit_x86.c
@@ -1043,7 +1043,7 @@ enum { xAX = 0, xCX, xDX, xBX, xSP, xBP, xSI, xDI,	// x86-64,i386 common
 
 #define emith_rw_offs_max()	0xffffffffU
 
-#define host_call(addr, args)
+#define host_call(addr, args) \
 	addr
 
 #ifdef __x86_64__


### PR DESCRIPTION
Some minor changes were needed for emit_ppc.c to get dynarec working on the ps3. We need to force load TOC and function address from opd section in emith_call_reg and emith_abijump_reg otherwise a crash would occur.