### PR TITLE
Libretro: Fix Wii compiling by adding required -ffat-lto-objects

### DIFF
--- a/Makefile.libretro
+++ b/Makefile.libretro
@@ -276,7 +276,7 @@ else ifeq ($(platform), wii)
 	TARGET := $(TARGET_NAME)_libretro_$(platform).a
 	CC = $(DEVKITPPC)/bin/powerpc-eabi-gcc$(EXE_EXT)
 	AR = $(DEVKITPPC)/bin/powerpc-eabi-ar$(EXE_EXT)
-	CFLAGS += -DGEKKO -DHW_RVL -mrvl -mcpu=750 -meabi -mhard-float
+	CFLAGS += -DGEKKO -DHW_RVL -mrvl -mcpu=750 -meabi -mhard-float -ffat-lto-objects
 	STATIC_LINKING = 1
 	STATIC_LINKING_LINK = 1
 


### PR DESCRIPTION
Otherwise when compiling the final dol for the Nintendo Wii version of the PicoDrive (Libretro) core will result in compilation errors because of "missing" Libretro dependencies.

It's a (dirty, quick-fix) workaround for stop the compiler messages of "plugin needed to handle lto object", meaning that some libraries weren't linked (?)

Maybe this needs a better fix, but this works for now.