### PR TITLE
drc: align tcache_default to 64k on arm

### DIFF
--- a/cpu/drc/cmn.c
+++ b/cpu/drc/cmn.c
@@ -10,7 +10,13 @@
 #include <pico/pico_int.h>
 #include "cmn.h"
 
-u8 ALIGNED(4096) tcache_default[DRC_TCACHE_SIZE];
+#if defined(__aarch64__) || defined(__VFP_FP__)
+// might be running on a 64k-page kernel
+#define PICO_PAGE_ALIGN 65536
+#else
+#define PICO_PAGE_ALIGN 4096
+#endif
+u8 ALIGNED(PICO_PAGE_ALIGN) tcache_default[DRC_TCACHE_SIZE];
 u8 *tcache;
 
 void drc_cmn_init(void)


### PR DESCRIPTION
Newer arm64 hw supports 64k pages, and recent Linux distros provide kernel packages like linux-image-generic-64k (can be used on r-pi4 with Ubuntu for example). It affects 32bit mode also, so assume that an arm32 binary compiled for vfp may be used on such kernel.

Without this mprotect() fails to set exec permission because of bad alignment.