### PR TITLE
Libretro: silence a compiler warning regarding to memmap

### DIFF
--- a/platform/libretro/libretro-common/memmap/memmap.c
+++ b/platform/libretro/libretro-common/memmap/memmap.c
@@ -21,6 +21,7 @@
  */
 
 #include <stdint.h>
+#include <stdlib.h>
 #include <memmap.h>
 
 #ifndef PROT_READ


### PR DESCRIPTION
Here we shut up (silence) a compiler warning produced when compiling the file **platform/libretro/libretro-common/memmap/memmap.c** when compiled for Libretro platforms, by adding the **stdlib.h** library definition.

I think with less warnings it's better, IMHO.