### PR TITLE
Libretro: pass required additional arguments for big-endian Nintendo platforms (GameCube, Wii, Wii U)

### DIFF
--- a/Makefile.libretro
+++ b/Makefile.libretro
@@ -267,7 +267,7 @@ else ifeq ($(platform), ngc)
 	TARGET := $(TARGET_NAME)_libretro_$(platform).a
 	CC = $(DEVKITPPC)/bin/powerpc-eabi-gcc$(EXE_EXT)
 	AR = $(DEVKITPPC)/bin/powerpc-eabi-ar$(EXE_EXT)
-	CFLAGS += -DGEKKO -DHW_DOL -mrvl -mcpu=750 -meabi -mhard-float
+	CFLAGS += -DGEKKO -DHW_DOL -mrvl -mcpu=750 -meabi -mhard-float -DMSB_FIRST -D__ppc__ -D__BIG_ENDIAN__ -DWORDS_BIGENDIAN=1
 	STATIC_LINKING = 1
 	STATIC_LINKING_LINK = 1
 
@@ -276,7 +276,7 @@ else ifeq ($(platform), wii)
 	TARGET := $(TARGET_NAME)_libretro_$(platform).a
 	CC = $(DEVKITPPC)/bin/powerpc-eabi-gcc$(EXE_EXT)
 	AR = $(DEVKITPPC)/bin/powerpc-eabi-ar$(EXE_EXT)
-	CFLAGS += -DGEKKO -DHW_RVL -mrvl -mcpu=750 -meabi -mhard-float -ffat-lto-objects
+	CFLAGS += -DGEKKO -DHW_RVL -mrvl -mcpu=750 -meabi -mhard-float -DMSB_FIRST -D__ppc__ -D__BIG_ENDIAN__ -DWORDS_BIGENDIAN=1 -ffat-lto-objects
 	STATIC_LINKING = 1
 	STATIC_LINKING_LINK = 1
 
@@ -286,7 +286,7 @@ else ifeq ($(platform), wiiu)
 	CC = $(DEVKITPPC)/bin/powerpc-eabi-gcc$(EXE_EXT)
 	CXX = $(DEVKITPPC)/bin/powerpc-eabi-g++$(EXE_EXT)
 	AR = $(DEVKITPPC)/bin/powerpc-eabi-ar$(EXE_EXT)
-	CFLAGS += -DGEKKO -DWIIU -DHW_RVL -DHW_WUP -mwup -mcpu=750 -meabi -mhard-float
+	CFLAGS += -DGEKKO -DWIIU -DHW_RVL -DHW_WUP -mwup -mcpu=750 -meabi -mhard-float -DMSB_FIRST -D__ppc__ -D__BIG_ENDIAN__ -DWORDS_BIGENDIAN=1
 	STATIC_LINKING = 1
 	STATIC_LINKING_LINK = 1
 


### PR DESCRIPTION
This attempts to fix some issues on PicoDrive when using this core on Nintendo consoles/platforms which are big-endian (Nintendo GameCube, Nintendo Wii, and Wii U).

All these three consoles have a PowerPC processor, which is big-endian.

Still is a work in progress, so i will leave the PR as draft for now.