### PR TITLE
remove fflush() call before exit()

### DIFF
--- a/pico/carthw/svp/compiler.c
+++ b/pico/carthw/svp/compiler.c
@@ -1797,7 +1797,6 @@ void *ssp_translate_block(int pc)
 
 	if (tcache_ptr - (u32 *)tcache > DRC_TCACHE_SIZE/4) {
 		elprintf(EL_ANOMALY|EL_STATUS|EL_SVP, "tcache overflow!\n");
-		fflush(stdout);
 		exit(1);
 	}
 


### PR DESCRIPTION
Hello,
attached is a patch that adds a cast to expected type to fix this compile error with gcc14 when building libretro core:
```
pico/carthw/svp/compiler.c: In function 'ssp_translate_block':
pico/carthw/svp/compiler.c:1800:24: error: passing argument 1 of 'rfflush' from incompatible pointer type [-Wincompatible-pointer-types]
 1800 |                 fflush(stdout);
      |                        ^~~~~~
      |                        |
      |                        FILE *
In file included from ./pico/pico_port.h:12,
                 from ./pico/pico_int.h:15,
                 from pico/carthw/svp/compiler.c:9:
platform/libretro/libretro-common/include/streams/file_stream_transforms.h:89:25: note: expected 'RFILE *' but argument is of type 'FILE *'
   89 | int64_t rfflush(RFILE * stream);
      |                 ~~~~~~~~^~~~~~
```