### PR TITLE
libretro Wii U Aroma compatibility fixes

### DIFF
--- a/Makefile.libretro
+++ b/Makefile.libretro
@@ -290,6 +290,8 @@ else ifeq ($(platform), wiiu)
 	CFLAGS += -DGEKKO -DWIIU -DHW_RVL -DHW_WUP -D__wiiu__ -ffunction-sections -fdata-sections -mcpu=750 -meabi -mhard-float
 	STATIC_LINKING = 1
 	STATIC_LINKING_LINK = 1
+	OBJS += platform/libretro/wiiu/libmemorymapping.o
+	CFLAGS += -isystem $(DEVKITPRO)/wut/include
 
 # Nintendo Switch (libtransistor)
 else ifeq ($(platform), switch)

--- a/Makefile.libretro
+++ b/Makefile.libretro
@@ -287,7 +287,7 @@ else ifeq ($(platform), wiiu)
 	CC = $(DEVKITPPC)/bin/powerpc-eabi-gcc$(EXE_EXT)
 	CXX = $(DEVKITPPC)/bin/powerpc-eabi-g++$(EXE_EXT)
 	AR = $(DEVKITPPC)/bin/powerpc-eabi-ar$(EXE_EXT)
-	CFLAGS += -DGEKKO -DWIIU -DHW_RVL -DHW_WUP -mwup -mcpu=750 -meabi -mhard-float
+	CFLAGS += -DGEKKO -DWIIU -DHW_RVL -DHW_WUP -D__wiiu__ -ffunction-sections -fdata-sections -mcpu=750 -meabi -mhard-float
 	STATIC_LINKING = 1
 	STATIC_LINKING_LINK = 1
 

--- a/cpu/drc/cmn.c
+++ b/cpu/drc/cmn.c
@@ -57,6 +57,9 @@ void drc_cmn_init(void)
 
 void drc_cmn_cleanup(void)
 {
+#ifdef HW_WUP
+  plat_mem_free_for_drc(tcache);
+#endif
 }
 
 // vim:shiftwidth=2:expandtab

--- a/pico/pico.h
+++ b/pico/pico.h
@@ -38,6 +38,7 @@ extern void  plat_munmap(void *ptr, size_t size);
 
 // memory for the dynarec; plat_mem_get_for_drc() can just return NULL
 extern void *plat_mem_get_for_drc(size_t size);
+extern void  plat_mem_free_for_drc(void *mem);
 extern int   plat_mem_set_exec(void *ptr, size_t size);
 
 // this one should handle display mode changes

--- a/platform/libretro/wiiu/libmemorymapping.c
+++ b/platform/libretro/wiiu/libmemorymapping.c
@@ -1,0 +1,50 @@
+#include "libmemorymapping.h"
+
+#include <coreinit/dynload.h>
+#include <stdbool.h>
+#include <stdint.h>
+
+// Aroma libmappedmemory - Maschell promises he won't break ABI here
+static void* (**MEMAllocFromMappedMemoryEx)(uint32_t size, int32_t alignment);
+static void* (**MEMFreeToMappedMemory)(void *ptr);
+static OSDynLoad_Module libmappedmemory;
+
+static bool wiiu_init_libmappedmemory() {
+  OSDynLoad_Error err;
+
+  // already ran?
+  if (MEMAllocFromMappedMemoryEx)
+    return true;
+
+  err = OSDynLoad_Acquire("homebrew_memorymapping", &libmappedmemory);
+  if (err != OS_DYNLOAD_OK)
+    return false;
+
+  err = OSDynLoad_FindExport(libmappedmemory, OS_DYNLOAD_EXPORT_DATA, "MEMAllocFromMappedMemoryEx", (void**)&MEMAllocFromMappedMemoryEx);
+  if (err != OS_DYNLOAD_OK)
+    return false;
+
+  err = OSDynLoad_FindExport(libmappedmemory, OS_DYNLOAD_EXPORT_DATA, "MEMFreeToMappedMemory", (void**)&MEMFreeToMappedMemory);
+  if (err != OS_DYNLOAD_OK)
+    return false;
+
+  return true;
+}
+
+void *wiiu_alloc_mappedmemory(uint32_t size, int32_t alignment) {
+  if (!wiiu_init_libmappedmemory()) return NULL;
+
+  return (*MEMAllocFromMappedMemoryEx)(size, alignment);
+}
+
+void wiiu_free_mappedmemory(void *mem) {
+  if (!wiiu_init_libmappedmemory()) return;
+
+  (*MEMFreeToMappedMemory)(mem);
+}
+
+void wiiu_deinit_mappedmemory(void) {
+  OSDynLoad_Release(libmappedmemory);
+  MEMAllocFromMappedMemoryEx = NULL;
+  MEMFreeToMappedMemory = NULL;
+}

--- a/platform/libretro/wiiu/libmemorymapping.h
+++ b/platform/libretro/wiiu/libmemorymapping.h
@@ -1,0 +1,10 @@
+#ifndef LIBMEMORYMAPPING_H
+#define LIBMEMORYMAPPING_H
+
+#include <stdint.h>
+
+void *wiiu_alloc_mappedmemory(uint32_t size, int32_t alignment);
+void wiiu_free_mappedmemory(void *mem);
+void wiiu_deinit_mappedmemory(void);
+
+#endif // LIBMEMORYMAPPING_H


### PR DESCRIPTION
Preparation for Aroma toolchains in RetroArch by tweaking the DRC memory and compiler flags. Should continue working fine on older systems since there is automatic fallbacks if the new methods fail.

We have to free the DRC memory after use, so add `plat_mem_free_for_drc` to the platform API, but in a Wii U ifdef so we don't have to touch every platform to add no-ops.