### PR TITLE
platform-miyoo: change to IPK release output

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,6 +30,7 @@ PicoDrive
 picodrive
 picodrive_libretro*
 PicoDrive*.opk
+PicoDrive*.ipk
 PicoDrive*.zip
 pico_int_offs.h
 amalgamate

--- a/Makefile
+++ b/Makefile
@@ -141,10 +141,12 @@ all: PicoDrive-dge.zip
 CFLAGS += -DSDL_SURFACE_SW # some legacy dinguces had bugs in HWSURFACE
 else
 ifneq (,$(filter %__MIYOO__, $(CFLAGS)))
-PicoDrive-miyoo.zip: .od_data
+PicoDrive-miyoo.ipk: .od_data
 	rm -f .od_data/default.*.desktop .od_data/PicoDrive.dge
-	cd .od_data && zip -9 -r ../$@ *
-all: PicoDrive-miyoo.zip
+	gm2xpkg -i platform/miyoo/pkg.cfg
+	mv picodrive.ipk $@
+	@gm2xpkg -c platform/miyoo/pkg.cfg >/dev/null 2>&1
+all: PicoDrive-miyoo.ipk
 else
 PicoDrive.opk: .od_data
 	rm -f .od_data/PicoDrive.dge

--- a/platform/miyoo/pkg.cfg
+++ b/platform/miyoo/pkg.cfg
@@ -1,0 +1,45 @@
+# NOTES:
+## All variable values should enclosed within double quotes: "<value>"
+## CONFIGURATION FILE for `gm2xpkg` script version:
+PKGVER="0.4"
+
+# EXEC commands (set to "1" anyone for desired outcome), you can instead use [OPTIONS] of `gm2xpkg`:
+PACKAGE=""
+ZIP=""
+IPK=""
+CLEAN=""
+
+# ENV VAR.
+## Specific (mandatory to provide!)
+TARGET="picodrive"  # replace with binary name
+VERSION="v2.00"  # replace with correct release version if exist
+
+## Generic - common to all apps (better to not modify)
+HOMEPATH="/mnt"
+RELEASEDIR=""
+ASSETSDIR=".od_data"
+OPKG_ASSETSDIR=""
+LINK="" # full name of gm2x link, modify if exec binary name may be different from target name - place in CWD (warning: it may be removed with CLEAN=1)
+ALIASES="" # full name (with ext) of *.txt file with new names for selector e.g. old_title=new_title - place in CWD
+MANUAL="" # full name (with ext) of *.man.txt file with usage description of target app - place in CWD
+
+## Link entries (better modify if no <target_name>.lnk file provided)
+TITLE="PicoDrive"
+DESCRI="MegaDrive/MegaCD/32X emulator"
+SELDIR="/mnt/roms/SMD"
+DESTDIR="emus" # default=apps
+SECTION="emulators" # default=applications
+
+## Custom entries (if needed then modify)
+TARGET_DIR=""  # the directory /$HOMEPATH/$DESTDIR/TARGET_DIR of executable binary if not provided the TARGET_DIR=$TARGET
+DOCS=("COPYING" "AUTHORS") # array of extra text files e.g. =("LICENSE" "CHANGELOG" "CONTRIBUTORS") which will be copied & converted to *.txt files for ease of use by frontend 
+
+## IPK control entries (if needed then modify)
+PRIORITY=""
+MAINTAINER="irixxxx"
+CONFFILES=""
+ARCH="" # default=arm - do not modify for ARM chips
+# CONTROL= # automated output of *.ipk control config file
+DEPENDS="" # list of dependency packages e.g. ="sdl, libpng" or ="sdl (>= 2.9.2), sdl_mixer (= ed76d39cda0735d26c14a3e4f4da996e420f6478)" provide only for shared libs build, otherwise ignored
+SOURCE="https://github.com/irixxxx/picodrive"
+LICENSE="Custom"


### PR DESCRIPTION
This requires to update miyoo container, so it can rely on current SDK with `gm2xpkg` ver. 0.4 in it.

You might want consider sending this script output to /dev/null as it in dev stage and will print some useless info.