### PR TITLE
Fix GCC 14 compilation

### DIFF
--- a/platform/libretro/libretro.c
+++ b/platform/libretro/libretro.c
@@ -37,6 +37,7 @@
 
 #if defined(RENDER_GSKIT_PS2)
 #include <malloc.h>
+#include <kernel.h>
 #include "libretro-common/include/libretro_gskit_ps2.h"
 #include "ps2/asm.h"
 #else


### PR DESCRIPTION
After updating PS2 toolchain in RetroArch now the picodrive core is failing in compilation,
This PR solves the issue.

Cheers