### PR TITLE
Improve timer functions

### DIFF
--- a/platform/psp/plat.c
+++ b/platform/psp/plat.c
@@ -181,30 +181,13 @@ int plat_is_dir(const char *path)
 /* current time in ms */
 unsigned int plat_get_ticks_ms(void)
 {
-	struct timeval tv;
-	unsigned int ret;
-
-	gettimeofday(&tv, NULL);
-
-	ret = (unsigned)tv.tv_sec * 1000;
-	/* approximate /= 1000 */
-	ret += ((unsigned)tv.tv_usec * 4194) >> 22;
-
-	return ret;
+	return clock() / 1000;
 }
 
 /* current time in us */
 unsigned int plat_get_ticks_us(void)
 {
-	struct timeval tv;
-	unsigned int ret;
-
-	gettimeofday(&tv, NULL);
-
-	ret = (unsigned)tv.tv_sec * 1000000;
-	ret += (unsigned)tv.tv_usec;
-
-	return ret;
+	return clock();
 }
 
 /* sleep for some time in ms */
@@ -216,15 +199,9 @@ void plat_sleep_ms(int ms)
 /* sleep for some time in us */
 void plat_wait_till_us(unsigned int us_to)
 {
-	unsigned int now;
-
-	now = plat_get_ticks_us();
-
-	while ((signed int)(us_to - now) > 512)
-	{
-		usleep(1024);
-		now = plat_get_ticks_us();
-	}
+	unsigned int ticks = clock();
+	if (us_to > ticks)
+		usleep(us_to - ticks);
 }
 
 /* wait until some event occurs, or timeout */


### PR DESCRIPTION
Stop using `gettimeofday` as the function is slower than `clock`.
Additionally, it has now the exactly same code as PS2.

Cheers.