### PR TITLE
fix some trivial warnings

### DIFF
--- a/pico/draw.c
+++ b/pico/draw.c
@@ -600,7 +600,7 @@ static void DrawWindow(int tstart, int tend, int prio, int sh,
   struct PicoVideo *pvid = &est->Pico->video;
   int tilex,ty,nametab,code,oldcode=-1,blank=-1; // The tile we know is blank
   int yshift,ymask;
-  u32 pack;
+  u32 pack=0;
   u32 *hc=NULL, lflags=0; // referenced in DrawTile
 
   yshift = 4, ymask = 0x7;
@@ -634,7 +634,7 @@ static void DrawWindow(int tstart, int tend, int prio, int sh,
     sh = (sh ? 0x80 : 0x00); // sh and low prio -> shadow
     for (; tilex < tend; tilex++)
     {
-      int dx, pal;
+      int dx, pal=0;
 
       code = PicoMem.vram[nametab + tilex];
       if ((code>>15) != prio) {
@@ -652,7 +652,7 @@ static void DrawWindow(int tstart, int tend, int prio, int sh,
     sh = lflags; // sh and high prio -> no shadow (lflags to suppress warning)
     for (; tilex < tend; tilex++)
     {
-      int dx, pal;
+      int dx, pal=0;
 
       code = PicoMem.vram[nametab + tilex];
       if((code>>15) != prio) {

--- a/pico/mode4.c
+++ b/pico/mode4.c
@@ -220,7 +220,6 @@ static void ParseSpritesM4(int scanline)
 
 static void DrawSpritesM4(void)
 {
-  struct PicoVideo *pv = &Pico.video;
   unsigned int pack;
   int zoomed = sprites_zoom & 0x1; // zoomed sprites, e.g. Earthworm Jim
   int s = sprites;
@@ -500,7 +499,6 @@ static void ParseSpritesTMS(int scanline)
 /* Draw sprites into a scanline, max 4 */
 static void DrawSpritesTMS(void)
 {
-  struct PicoVideo *pv = &Pico.video;
   unsigned int pack;
   int zoomed = sprites_zoom & 0x1; // zoomed sprites
   int s = sprites;

--- a/pico/pico_cmn.c
+++ b/pico/pico_cmn.c
@@ -50,7 +50,7 @@ static int SekSyncM68k(int once)
     // the Z80 CPU is stealing some bus cycles from the 68K main CPU when 
     // accessing the main bus. Account for these by shortening the time
     // the 68K CPU runs.
-    int z80_buscyc = (Pico.t.z80_buscycles >> 4+(~Pico.m.scanline & 1));
+    int z80_buscyc = Pico.t.z80_buscycles >> (4+(~Pico.m.scanline & 1));
     // NB the Z80 isn't fast enough to steal more than half the bandwidth.
     // the fastest would be POP cc which takes 10+~3.3*2 z-cyc (~35 cyc) for a
     // 16 bit value, but 68k is only blocked for ~16 cyc for the 2 bus cycles.

--- a/pico/videoport.c
+++ b/pico/videoport.c
@@ -1229,8 +1229,6 @@ void PicoVideoCacheSAT(int load)
 
 int PicoVideoSave(void *buf)
 {
-  struct VdpFIFO *vf = &VdpFIFO;
-  struct PicoVideo *pv = &Pico.video;
   u8 *bp = buf;
   int i;
 

--- a/platform/common/menu_pico.c
+++ b/platform/common/menu_pico.c
@@ -1819,4 +1819,7 @@ void menu_init(void)
 		e_menu_options[i].name = "CPU clock";
 		e_menu_options[i].enabled = 1;
 	}
+	// suppress warnings about unused libpicofe funcs
+	(void)me_loop;
+	(void)menu_loop_romsel;
 }


### PR DESCRIPTION
It just annoys having to check every time if it's not something I introduced. Zero initialization things are for false-positives, but shouldn't do any harm I think.