### PR TITLE
add needed endian defines for almost all supported platforms

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -229,7 +229,7 @@ USE_FRONTEND = 1
 PLATFORM_MP3 ?= 1
 endif
 ifeq "$(PLATFORM)" "psp"
-CFLAGS += -DUSE_BGR565 -G8 # -DLPRINTF_STDIO -DFW15
+CFLAGS += -DUSE_BGR565 -G8 # -DLPRINTF_STDIO -DFW15 -DBYTE_ORDER=LITTLE_ENDIAN
 LDLIBS += -lpspgu -lpspge -lpsppower -lpspaudio -lpspdisplay -lpspaudiocodec
 LDLIBS += -lpspctrl
 platform/common/main.o: CFLAGS += -Dmain=pico_main
@@ -242,7 +242,7 @@ OBJS += platform/psp/mp3.o
 USE_FRONTEND = 1
 endif
 ifeq "$(PLATFORM)" "ps2"
-CFLAGS += -DUSE_BGR555 # -DLOG_TO_FILE
+CFLAGS += -DUSE_BGR555 -DBYTE_ORDER=LITTLE_ENDIAN # -DLOG_TO_FILE
 LDLIBS += -lpatches -lgskit -ldmakit -lps2_drivers
 OBJS += platform/ps2/plat.o
 OBJS += platform/ps2/emu.o
@@ -250,7 +250,7 @@ OBJS += platform/ps2/in_ps2.o
 USE_FRONTEND = 1
 endif
 ifeq "$(PLATFORM)" "win32"
-CFLAGS += -DSDL_OVERLAY_2X -DSDL_BUFFER_3X -DSDL_REDRAW_EVT
+CFLAGS += -DSDL_OVERLAY_2X -DSDL_BUFFER_3X -DSDL_REDRAW_EVT -DBYTE_ORDER=LITTLE_ENDIAN
 OBJS += platform/win32/plat.o
 OBJS += platform/linux/emu.o platform/linux/blit.o # FIXME
 OBJS += platform/common/plat_sdl.o platform/common/inputmap_kbd.o

--- a/Makefile.libretro
+++ b/Makefile.libretro
@@ -56,7 +56,7 @@ ifeq ($(platform), unix)
 	TARGET := $(TARGET_NAME)_libretro.$(EXT)
 	fpic := -fPIC
 	SHARED := -shared
-	CFLAGS += -DFAMEC_NO_GOTOS
+	CFLAGS += -DFAMEC_NO_GOTOS -DBYTE_ORDER=LITTLE_ENDIAN
 ifneq ($(findstring SunOS,$(shell uname -a)),)
 	CC=gcc
 endif
@@ -67,7 +67,7 @@ else ifneq (,$(findstring x86,$(platform)))
 	ARCH := x86
         fpic := -fPIC
 	SHARED := -shared
-	CFLAGS += -DFAMEC_NO_GOTOS
+	CFLAGS += -DFAMEC_NO_GOTOS -DBYTE_ORDER=LITTLE_ENDIAN
 
 # AARCH64 generic
 else ifeq ($(platform), aarch64)
@@ -75,7 +75,7 @@ else ifeq ($(platform), aarch64)
 	ARCH = aarch64
         fpic := -fPIC
 	SHARED := -shared
-	CFLAGS += -DFAMEC_NO_GOTOS
+	CFLAGS += -DFAMEC_NO_GOTOS -DBYTE_ORDER=LITTLE_ENDIAN
 
 # Portable Linux
 else ifeq ($(platform), linux-portable)
@@ -84,7 +84,7 @@ else ifeq ($(platform), linux-portable)
 	SHARED := -shared -nostdlib
 	fpic := -fPIC
 	LIBM :=
-	CFLAGS += -DFAMEC_NO_GOTOS
+	CFLAGS += -DFAMEC_NO_GOTOS -DBYTE_ORDER=LITTLE_ENDIAN
 
 # OS X
 else ifeq ($(platform), osx)
@@ -100,6 +100,12 @@ else ifeq ($(platform), osx)
         CPPFLAGS += $(TARGET_RULE)
         CXXFLAGS += $(TARGET_RULE)
         LDFLAGS  += $(TARGET_RULE)
+   endif
+
+   ifeq ($(arch),ppc)
+      CFLAGS += -DBYTE_ORDER=BIG_ENDIAN
+   else
+      CFLAGS += -DBYTE_ORDER=LITTLE_ENDIAN
    endif
 
    ifndef ($(NOUNIVERSAL))
@@ -118,7 +124,7 @@ else ifeq ($(platform), staticios)
 	CXX = clang++ -arch armv7 -arch arm64 -isysroot $(IOSSDK)
 	CC_AS = perl ./tools/gas-preprocessor.pl $(CC)
 	CFLAGS += -marm 
-	CFLAGS += -DIOS
+	CFLAGS += -DIOS -DBYTE_ORDER=LITTLE_ENDIAN
 
 	CC     += -miphoneos-version-min=8.0
 	CXX    += -miphoneos-version-min=8.0
@@ -150,7 +156,7 @@ else ifneq (,$(findstring ios,$(platform)))
 	  ASFLAGS += -mcpu=cortex-a8 -mtune=cortex-a8 -mfpu=neon
 	  NO_ARM_ASM = 1
 	endif
-	CFLAGS += -DIOS
+	CFLAGS += -DIOS -DBYTE_ORDER=LITTLE_ENDIAN
 
 ifeq ($(platform),$(filter $(platform),ios9 ios-arm64))
 	MINVERSION = -miphoneos-version-min=8.0
@@ -175,14 +181,14 @@ else ifeq ($(platform), tvos-arm64)
 	CC      = cc -arch arm64 -isysroot $(IOSSDK)
 	CXX     = c++ -arch arm64 -isysroot $(IOSSDK)
 	CFLAGS += -marm -DARM -D__aarch64__=1 
-	CFLAGS += -DIOS
+	CFLAGS += -DIOS -DBYTE_ORDER=LITTLE_ENDIAN
 
 # Lightweight PS3 Homebrew SDK
 else ifneq (,$(filter $(platform), ps3 psl1ght))
 	TARGET := $(TARGET_NAME)_libretro_$(platform).a
 	CC = $(PS3DEV)/ppu/bin/ppu-$(COMMONLV)gcc$(EXE_EXT)
 	AR = $(PS3DEV)/ppu/bin/ppu-$(COMMONLV)ar$(EXE_EXT)
-	CFLAGS += -DFAMEC_NO_GOTOS -D__PS3__
+	CFLAGS += -DFAMEC_NO_GOTOS -D__PS3__ -DBYTE_ORDER=BIG_ENDIAN
 	STATIC_LINKING = 1
 	STATIC_LINKING_LINK = 1
 	ifeq ($(platform), psl1ght)
@@ -195,7 +201,7 @@ else ifeq ($(platform), psp1)
 	TARGET := $(TARGET_NAME)_libretro_$(platform).a
 	CC = psp-gcc$(EXE_EXT)
 	AR = psp-ar$(EXE_EXT)
-	CFLAGS += -DPSP -G0 -ftracer
+	CFLAGS += -DPSP -G0 -ftracer -DBYTE_ORDER=LITTLE_ENDIAN
 	CFLAGS += -I$(shell psp-config --pspsdk-path)/include
 	STATIC_LINKING = 1
 	STATIC_LINKING_LINK = 1
@@ -206,7 +212,7 @@ else ifeq ($(platform), ps2)
 	TARGET := $(TARGET_NAME)_libretro_$(platform).a
 	CC = mips64r5900el-ps2-elf-gcc$(EXE_EXT)
 	AR = mips64r5900el-ps2-elf-ar$(EXE_EXT)
-	CFLAGS += -Wall -DPS2 -D_EE -DUSE_BGR555 -DFAMEC_NO_GOTOS -DRENDER_GSKIT_PS2 -fsingle-precision-constant
+	CFLAGS += -Wall -DPS2 -D_EE -DUSE_BGR555 -DFAMEC_NO_GOTOS -DRENDER_GSKIT_PS2 -fsingle-precision-constant -DBYTE_ORDER=LITTLE_ENDIAN
 	CFLAGS += -I$(PS2DEV)/gsKit/include -I$(PS2SDK)/ee/include -I$(PS2SDK)/common/include
 	STATIC_LINKING = 1
 	STATIC_LINKING_LINK = 1
@@ -217,7 +223,7 @@ else ifeq ($(platform), ctr)
 	CC = $(DEVKITARM)/bin/arm-none-eabi-gcc$(EXE_EXT)
 	CXX = $(DEVKITARM)/bin/arm-none-eabi-g++$(EXE_EXT)
 	AR = $(DEVKITARM)/bin/arm-none-eabi-ar$(EXE_EXT)
-	CFLAGS += -DARM11 -D_3DS
+	CFLAGS += -DARM11 -D_3DS -DBYTE_ORDER=LITTLE_ENDIAN
 	CFLAGS += -march=armv6k -mtune=mpcore -mfloat-abi=hard -marm -mfpu=vfp
 	CFLAGS += -Wall -mword-relocations
 	CFLAGS += -fomit-frame-pointer -ffast-math
@@ -230,6 +236,7 @@ else ifeq ($(platform), ctr)
 else ifneq (,$(findstring rpi,$(platform)))
 	CFLAGS += -Wall -mword-relocations
 	CFLAGS += -fomit-frame-pointer -ffast-math
+	CFLAGS += -DBYTE_ORDER=LITTLE_ENDIAN
 
 	TARGET := $(TARGET_NAME)_libretro.so
 	SHARED := -shared
@@ -248,7 +255,7 @@ else ifeq ($(platform), vita)
 	TARGET := $(TARGET_NAME)_libretro_$(platform).a
 	CC = arm-vita-eabi-gcc$(EXE_EXT)
 	AR = arm-vita-eabi-ar$(EXE_EXT)
-	CFLAGS += -DVITA
+	CFLAGS += -DVITA -DBYTE_ORDER=LITTLE_ENDIAN
 	CFLAGS += -marm -mfpu=neon -mcpu=cortex-a9 -march=armv7-a -mfloat-abi=hard -ffast-math
 	CFLAGS += -fno-asynchronous-unwind-tables -ftree-vectorize -funroll-loops
 	CFLAGS += -mword-relocations -fno-unwind-tables
@@ -261,14 +268,14 @@ else ifeq ($(platform), xenon)
 	TARGET := $(TARGET_NAME)_libretro_xenon360.a
 	CC = xenon-gcc$(EXE_EXT)
 	AR = xenon-ar$(EXE_EXT)
-	CFLAGS += -D__LIBXENON__ -m32
+	CFLAGS += -D__LIBXENON__ -m32 -DBYTE_ORDER=BIG_ENDIAN
 
 # Nintendo Game Cube
 else ifeq ($(platform), ngc)
 	TARGET := $(TARGET_NAME)_libretro_$(platform).a
 	CC = $(DEVKITPPC)/bin/powerpc-eabi-gcc$(EXE_EXT)
 	AR = $(DEVKITPPC)/bin/powerpc-eabi-ar$(EXE_EXT)
-	CFLAGS += -DGEKKO -DHW_DOL -mrvl -mcpu=750 -meabi -mhard-float
+	CFLAGS += -DGEKKO -DHW_DOL -mrvl -mcpu=750 -meabi -mhard-float -DBYTE_ORDER=BIG_ENDIAN
 	STATIC_LINKING = 1
 	STATIC_LINKING_LINK = 1
 
@@ -277,7 +284,7 @@ else ifeq ($(platform), wii)
 	TARGET := $(TARGET_NAME)_libretro_$(platform).a
 	CC = $(DEVKITPPC)/bin/powerpc-eabi-gcc$(EXE_EXT)
 	AR = $(DEVKITPPC)/bin/powerpc-eabi-ar$(EXE_EXT)
-	CFLAGS += -DGEKKO -DHW_RVL -mrvl -mcpu=750 -meabi -mhard-float -ffat-lto-objects
+	CFLAGS += -DGEKKO -DHW_RVL -mrvl -mcpu=750 -meabi -mhard-float -ffat-lto-objects -DBYTE_ORDER=BIG_ENDIAN
 	STATIC_LINKING = 1
 	STATIC_LINKING_LINK = 1
 
@@ -287,7 +294,7 @@ else ifeq ($(platform), wiiu)
 	CC = $(DEVKITPPC)/bin/powerpc-eabi-gcc$(EXE_EXT)
 	CXX = $(DEVKITPPC)/bin/powerpc-eabi-g++$(EXE_EXT)
 	AR = $(DEVKITPPC)/bin/powerpc-eabi-ar$(EXE_EXT)
-	CFLAGS += -DGEKKO -DWIIU -DHW_RVL -DHW_WUP -mwup -mcpu=750 -meabi -mhard-float
+	CFLAGS += -DGEKKO -DWIIU -DHW_RVL -DHW_WUP -mwup -mcpu=750 -meabi -mhard-float -DBYTE_ORDER=BIG_ENDIAN
 	STATIC_LINKING = 1
 	STATIC_LINKING_LINK = 1
 
@@ -304,7 +311,7 @@ else ifeq ($(platform), libnx)
 	TARGET := $(TARGET_NAME)_libretro_$(platform).a
 	CFLAGS += -O3 -fomit-frame-pointer -ffast-math -I$(DEVKITPRO)/libnx/include/ -fPIE -Wl,--allow-multiple-definition
 	CFLAGS += -specs=$(DEVKITPRO)/libnx/switch.specs
-	CFLAGS += -D__SWITCH__ -DHAVE_LIBNX
+	CFLAGS += -D__SWITCH__ -DHAVE_LIBNX -DBYTE_ORDER=LITTLE_ENDIAN
 	CFLAGS += -DARM -D__aarch64__=1 -march=armv8-a -mtune=cortex-a57 -mtp=soft -ffast-math -mcpu=cortex-a57+crc+fp+simd -ffunction-sections
 	CFLAGS += -Ifrontend/switch -ftree-vectorize
 	STATIC_LINKING=1
@@ -317,7 +324,7 @@ else ifeq ($(platform), qnx)
 	fpic := -fPIC
 	CC = qcc -Vgcc_ntoarmv7le
 	CC_AS = $(CC)
-	CFLAGS += -DBASE_ADDR_FIXED=0 -D__BLACKBERRY_QNX__ -marm -mcpu=cortex-a9 -mtune=cortex-a9 -mfpu=neon -mfloat-abi=softfp
+	CFLAGS += -DBASE_ADDR_FIXED=0 -D__BLACKBERRY_QNX__ -marm -mcpu=cortex-a9 -mtune=cortex-a9 -mfpu=neon -mfloat-abi=softfp -DBYTE_ORDER=LITTLE_ENDIAN
 	ASFLAGS +=  -mcpu=cortex-a9 -mfpu=neon -mfloat-abi=softfp
 
 # (armv7 a7, hard point, neon based) ### 
@@ -333,7 +340,8 @@ else ifeq ($(platform), classic_armv7_a7)
 	-falign-functions=1 -falign-jumps=1 -falign-loops=1 \
 	-fno-unwind-tables -fno-asynchronous-unwind-tables -fno-unroll-loops \
 	-fmerge-all-constants -fno-math-errno \
-	-marm -mtune=cortex-a7 -mfpu=neon-vfpv4 -mfloat-abi=hard
+	-marm -mtune=cortex-a7 -mfpu=neon-vfpv4 -mfloat-abi=hard \
+	-DBYTE_ORDER=LITTLE_ENDIAN
 	CXXFLAGS += $(CFLAGS)
 	CPPFLAGS += $(CFLAGS)
 	ASFLAGS += $(CFLAGS)
@@ -362,7 +370,8 @@ else ifeq ($(platform), classic_armv8_a35)
 		-falign-functions=1 -falign-jumps=1 -falign-loops=1 \
 		-fno-unwind-tables -fno-asynchronous-unwind-tables -fno-unroll-loops \
 		-fmerge-all-constants -fno-math-errno -fno-strict-aliasing \
-		-marm -mtune=cortex-a35 -mfpu=neon-fp-armv8 -mfloat-abi=hard
+		-marm -mtune=cortex-a35 -mfpu=neon-fp-armv8 -mfloat-abi=hard \
+		-DBYTE_ORDER=LITTLE_ENDIAN
 	CXXFLAGS += $(CFLAGS)
 	CPPFLAGS += $(CFLAGS)
 	ASFLAGS += $(CFLAGS)
@@ -380,7 +389,7 @@ else ifeq ($(platform), arm64)
 	ARCH = aarch64
 	fpic := -fPIC
 	SHARED := -shared
-	CFLAGS += -DFAMEC_NO_GOTOS
+	CFLAGS += -DFAMEC_NO_GOTOS -DBYTE_ORDER=LITTLE_ENDIAN
 
 # AARCH64 generic
 else ifeq ($(platform), aarch64)
@@ -388,13 +397,14 @@ else ifeq ($(platform), aarch64)
 	ARCH = aarch64
 	fpic := -fPIC
 	SHARED := -shared
-	CFLAGS += -DFAMEC_NO_GOTOS
+	CFLAGS += -DFAMEC_NO_GOTOS -DBYTE_ORDER=LITTLE_ENDIAN
 
 # ARM
 else ifneq (,$(findstring armv,$(platform)))
 	TARGET := $(TARGET_NAME)_libretro.so
 	SHARED := -shared -Wl,--no-undefined,-Bsymbolic
 	fpic := -fPIC
+	CFLAGS += -DBYTE_ORDER=LITTLE_ENDIAN
 	ifneq (,$(findstring cortexa5,$(platform)))
 		CFLAGS += -marm -mcpu=cortex-a5
 		ASFLAGS += -mcpu=cortex-a5
@@ -429,6 +439,7 @@ else ifneq (,$(findstring armv,$(platform)))
 else ifeq ($(platform), emscripten) 
 	TARGET := $(TARGET_NAME)_libretro_$(platform).bc
 	ARCH = unknown
+	CFLAGS += -DBYTE_ORDER=LITTLE_ENDIAN
 
 	STATIC_LINKING = 1
 
@@ -444,7 +455,7 @@ endif
 	SHARED := -shared -nostdlib
 	fpic := -fPIC
 	LIBM :=
-	CFLAGS += -fomit-frame-pointer -ffast-math -march=mips32 -mtune=mips32 -D__GCW0__
+	CFLAGS += -fomit-frame-pointer -ffast-math -march=mips32 -mtune=mips32 -D__GCW0__ -DBYTE_ORDER=LITTLE_ENDIAN
 	# clear_cache uses SYNCI instead of a syscall
 	CFLAGS += -DMIPS_USE_SYNCI
 	LOW_MEMORY = 1
@@ -461,7 +472,7 @@ endif
 	SHARED := -shared -nostdlib
 	fpic := -fPIC
 	LIBM :=
-	CFLAGS += -fomit-frame-pointer -ffast-math -march=mips32 -mtune=mips32r2 -mhard-float -D__GCW0__
+	CFLAGS += -fomit-frame-pointer -ffast-math -march=mips32 -mtune=mips32r2 -mhard-float -D__GCW0__ -DBYTE_ORDER=LITTLE_ENDIAN
 	# clear_cache uses SYNCI instead of a syscall
 	CFLAGS += -DMIPS_USE_SYNCI
 	
@@ -477,7 +488,7 @@ endif
 	SHARED := -shared -nostdlib
 	fpic := -fPIC
 	LIBM :=
-	CFLAGS += -fomit-frame-pointer -ffast-math -march=mips32 -mtune=mips32 -mhard-float -D__GCW0__
+	CFLAGS += -fomit-frame-pointer -ffast-math -march=mips32 -mtune=mips32 -mhard-float -D__GCW0__ -DBYTE_ORDER=LITTLE_ENDIAN
 	# clear_cache uses SYNCI instead of a syscall
 	CFLAGS += -DMIPS_USE_SYNCI
 	
@@ -489,7 +500,7 @@ else ifeq ($(platform), miyoo)
 	SHARED := -shared -nostdlib
 	fpic := -fPIC
 	LIBM :=
-	CFLAGS += -fomit-frame-pointer -ffast-math -march=armv5te -mtune=arm926ej-s -D__GCW0__
+	CFLAGS += -fomit-frame-pointer -ffast-math -march=armv5te -mtune=arm926ej-s -D__GCW0__ -DBYTE_ORDER=LITTLE_ENDIAN
 	HAVE_ARMv6 = 0
 	LOW_MEMORY = 1
 
@@ -515,7 +526,7 @@ else ifneq (,$(findstring windows_msvc2017,$(platform)))
 	LIBM :=
 	NO_ALIGN_FUNCTIONS = 1
 
-	CFLAGS += -DHAVE_VSNPRINTF
+	CFLAGS += -DHAVE_VSNPRINTF -DBYTE_ORDER=LITTLE_ENDIAN
 	CFLAGS += $(MSVC2017CompileFlags)
 	CXXFLAGS += $(MSVC2017CompileFlags)
 


### PR DESCRIPTION
otherwise the TREMOR library won't be able to select the correct variables depending of the architecture.

for little-endian platforms, add to CFLAGS the following: -DBYTE_ORDER=LITTLE_ENDIAN
for big-endian platforms, add to CFLAGS the following: -DBYTE_ORDER=BIG_ENDIAN