### PR TITLE
reinstate logic for disable many OGG open files at the same time, enable it on GC/Wii/Wii U, add defines for libvorbis.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -341,6 +341,7 @@ CFLAGS += -I$(TREMOR) -DUSE_TREMOR
 OBJS += $(TREMOR_OBJS)
 else
 LDLIBS += -lvorbisfile
+CFLAGS += -DUSE_SYS_VORBIS
 endif
 
 ifeq (1,$(use_libchdr))

--- a/Makefile.libretro
+++ b/Makefile.libretro
@@ -268,7 +268,7 @@ else ifeq ($(platform), ngc)
 	TARGET := $(TARGET_NAME)_libretro_$(platform).a
 	CC = $(DEVKITPPC)/bin/powerpc-eabi-gcc$(EXE_EXT)
 	AR = $(DEVKITPPC)/bin/powerpc-eabi-ar$(EXE_EXT)
-	CFLAGS += -DGEKKO -DHW_DOL -mrvl -mcpu=750 -meabi -mhard-float
+	CFLAGS += -DGEKKO -DHW_DOL -mrvl -mcpu=750 -meabi -mhard-float -DDISABLE_MANY_OGG_OPEN_FILES
 	STATIC_LINKING = 1
 	STATIC_LINKING_LINK = 1
 
@@ -277,7 +277,7 @@ else ifeq ($(platform), wii)
 	TARGET := $(TARGET_NAME)_libretro_$(platform).a
 	CC = $(DEVKITPPC)/bin/powerpc-eabi-gcc$(EXE_EXT)
 	AR = $(DEVKITPPC)/bin/powerpc-eabi-ar$(EXE_EXT)
-	CFLAGS += -DGEKKO -DHW_RVL -mrvl -mcpu=750 -meabi -mhard-float -ffat-lto-objects
+	CFLAGS += -DGEKKO -DHW_RVL -mrvl -mcpu=750 -meabi -mhard-float -ffat-lto-objects -DDISABLE_MANY_OGG_OPEN_FILES
 	STATIC_LINKING = 1
 	STATIC_LINKING_LINK = 1
 
@@ -287,7 +287,7 @@ else ifeq ($(platform), wiiu)
 	CC = $(DEVKITPPC)/bin/powerpc-eabi-gcc$(EXE_EXT)
 	CXX = $(DEVKITPPC)/bin/powerpc-eabi-g++$(EXE_EXT)
 	AR = $(DEVKITPPC)/bin/powerpc-eabi-ar$(EXE_EXT)
-	CFLAGS += -DGEKKO -DWIIU -DHW_RVL -DHW_WUP -mwup -mcpu=750 -meabi -mhard-float
+	CFLAGS += -DGEKKO -DWIIU -DHW_RVL -DHW_WUP -mwup -mcpu=750 -meabi -mhard-float -DDISABLE_MANY_OGG_OPEN_FILES
 	STATIC_LINKING = 1
 	STATIC_LINKING_LINK = 1
 

--- a/pico/cd/cdd.c
+++ b/pico/cd/cdd.c
@@ -134,7 +134,7 @@ static const unsigned char waveHeader[32] =
 };
 #endif
 
-#ifdef USE_LIBTREMOR
+#if defined(USE_TREMOR) || defined(USE_SYS_VORBIS)
 #ifdef DISABLE_MANY_OGG_OPEN_FILES
 static void ogg_free(int i)
 {
@@ -214,7 +214,7 @@ void cdd_play_audio(int index, int lba)
 
 static void cdd_seek(int index, int lba)
 {
-#ifdef USE_LIBTREMOR
+#if defined(USE_TREMOR) || defined(USE_SYS_VORBIS)
 #ifdef DISABLE_MANY_OGG_OPEN_FILES
   /* close previous track VORBIS file structure to save memory */
   if (is_audio(cdd.index) && cdd.toc.tracks[cdd.index].vf.datasource)

--- a/platform/common/ogg.c
+++ b/platform/common/ogg.c
@@ -11,10 +11,10 @@
 #include <pico/pico_int.h>
 #include <pico/sound/mix.h>
 
-#ifdef USE_TREMOR
+#if defined(USE_TREMOR)
 #include "tremor/ivorbisfile.h"
 #define ov_read(vf,b,l,be,w,s,ip) (ov_read)(vf,b,l,ip)
-#else
+#elif defined(USE_SYS_VORBIS)
 #include <vorbis/vorbisfile.h>
 #define ov_time_total(vf,ix) (ov_time_total)(vf,ix)*1000
 #endif


### PR DESCRIPTION
if using libvorbis, it will use the flag USE_SYS_VORBIS.

also enables again the logic of having only one OGG file open at the same time for save RAM memory. Useful on low-end devices. Applies on both libtremor and libvorbis.

By default, GC/Wii/Wii U libretro cores will use this option, as they have limited RAM.

To enable disabling multiple OGG files open at once, add to CFLAGS the flag **-DDISABLE_MANY_OGG_OPEN_FILES** in the platform you want to use.

Taken from Genesis Plus GX.