### PR TITLE
Support Web platform

### DIFF
--- a/Makefile.web
+++ b/Makefile.web
@@ -1,0 +1,157 @@
+# Makefile for PicoDrive Web/Emscripten build (asm.js)
+#
+# Usage:
+#   make -f Makefile.web
+#   or: emmake make -f Makefile.web
+#
+
+# Emscripten compiler
+CC = emcc
+LD = emcc
+AR = emar
+
+TARGET = picodrive.js
+
+# Build output directory
+BUILD_DIR = build-web
+
+# Core flags
+CFLAGS = -I. -Izlib -O2 -DNDEBUG
+CFLAGS += -Wall -Wno-unused-variable -Wno-unused-function
+CFLAGS += -DFAMEC_NO_GOTOS
+
+# Emscripten specific flags for asm.js
+LDFLAGS = -O2
+LDFLAGS += -s WASM=0
+LDFLAGS += -s ALLOW_MEMORY_GROWTH=1
+LDFLAGS += -s INITIAL_MEMORY=67108864
+LDFLAGS += -s EXPORTED_FUNCTIONS='["_main","_pico_init","_pico_exit","_pico_get_rom_buffer","_pico_load_rom","_pico_reset","_pico_set_input","_pico_run_frame","_pico_get_video_buffer","_pico_get_video_width","_pico_get_video_height","_pico_is_pal","_pico_get_rom_name","_pico_get_button_up","_pico_get_button_down","_pico_get_button_left","_pico_get_button_right","_pico_get_button_b","_pico_get_button_c","_pico_get_button_a","_pico_get_button_start","_pico_get_button_z","_pico_get_button_y","_pico_get_button_x","_pico_get_button_mode","_pico_set_region","_pico_get_region","_pico_state_save","_pico_state_load","_pico_state_exists","_pico_get_state_buffer","_pico_get_state_size","_pico_get_state_load_buffer","_malloc","_free"]'
+LDFLAGS += -s EXPORTED_RUNTIME_METHODS='["ccall","cwrap","getValue","setValue","HEAP8","HEAP16","HEAP32","HEAPU8","HEAPU16","HEAPU32"]'
+LDFLAGS += -s INVOKE_RUN=0
+LDFLAGS += -s EXIT_RUNTIME=0
+
+# CPU emulation selection - use portable C implementations
+use_fame = 1
+use_cz80 = 1
+use_cyclone = 0
+use_drz80 = 0
+use_sh2drc = 0
+use_svpdrc = 0
+
+# Disable ARM-specific assembly
+asm_memory = 0
+asm_render = 0
+asm_ym2612 = 0
+asm_misc = 0
+asm_cdmemory = 0
+asm_mix = 0
+asm_32xdraw = 0
+asm_32xmemory = 0
+
+# Disable libchdr for now (complex dependencies)
+use_libchdr = 0
+
+# Platform
+PLATFORM = web
+
+# Core emulation sources
+SRCS = pico/pico.c pico/cart.c pico/memory.c \
+	pico/state.c pico/sek.c pico/z80if.c \
+	pico/videoport.c pico/draw2.c pico/draw.c \
+	pico/mode4.c pico/misc.c pico/eeprom.c \
+	pico/patch.c pico/debug.c pico/media.c
+
+# SMS
+SRCS += pico/sms.c
+
+# CD (without CHD support for now)
+SRCS += pico/cd/mcd.c pico/cd/memory.c pico/cd/sek.c \
+	pico/cd/cdc.c pico/cd/cdd.c pico/cd/cd_image.c \
+	pico/cd/cd_parse.c pico/cd/gfx.c pico/cd/gfx_dma.c \
+	pico/cd/misc.c pico/cd/pcm.c pico/cd/megasd.c
+
+# 32X
+SRCS += pico/32x/32x.c pico/32x/memory.c pico/32x/draw.c \
+	pico/32x/sh2soc.c pico/32x/pwm.c
+
+# Pico (Sega Pico toy)
+SRCS += pico/pico/pico.c pico/pico/memory.c pico/pico/xpcm.c
+
+# Cart hardware
+SRCS += pico/carthw/carthw.c pico/carthw/eeprom_spi.c
+SRCS += pico/carthw/svp/svp.c pico/carthw/svp/memory.c pico/carthw/svp/ssp16.c
+
+# Sound
+SRCS += pico/sound/sound.c pico/sound/resampler.c
+SRCS += pico/sound/sn76496.c pico/sound/ym2612.c
+SRCS += pico/sound/ym2413.c pico/sound/mix.c
+SRCS += pico/sound/vgm.c
+
+# CPU cores - M68K (FAME - portable C)
+CFLAGS += -DEMU_F68K
+SRCS += cpu/fame/famec.c
+
+# CPU cores - Z80 (CZ80 - portable C)
+CFLAGS += -D_USE_CZ80
+SRCS += cpu/cz80/cz80.c
+
+# CPU cores - SH2 (interpreter only, no DRC)
+SRCS += cpu/drc/cmn.c
+SRCS += cpu/sh2/sh2.c
+SRCS += cpu/sh2/mame/sh2pico.c
+
+# Unzip support (for zipped ROMs)
+SRCS += unzip/unzip.c
+
+# Zlib (required for compressed save states and ZIP support)
+SRCS += zlib/adler32.c zlib/compress.c zlib/crc32.c zlib/deflate.c \
+	zlib/gzio.c zlib/inffast.c zlib/inflate.c zlib/inftrees.c \
+	zlib/trees.c zlib/uncompr.c zlib/zutil.c
+
+# Web platform layer
+SRCS += platform/web/web.c
+
+# Object files
+OBJS = $(SRCS:.c=.o)
+
+# Default target
+all: $(BUILD_DIR) $(BUILD_DIR)/$(TARGET) $(BUILD_DIR)/index.html
+
+$(BUILD_DIR):
+	mkdir -p $(BUILD_DIR)
+
+# Compile C files
+%.o: %.c
+	$(CC) -c -o $@ $< $(CFLAGS)
+
+# Link
+$(BUILD_DIR)/$(TARGET): $(OBJS)
+	$(LD) $(OBJS) -o $@ $(LDFLAGS)
+	@echo "Build complete: $@"
+
+# Copy HTML file
+$(BUILD_DIR)/index.html: platform/web/index.html
+	cp $< $@
+
+# Clean
+clean:
+	rm -f $(OBJS)
+	rm -rf $(BUILD_DIR)
+
+# Show help
+help:
+	@echo "PicoDrive Web Build"
+	@echo ""
+	@echo "Targets:"
+	@echo "  all     - Build the asm.js version (default)"
+	@echo "  clean   - Remove build artifacts"
+	@echo ""
+	@echo "Output:"
+	@echo "  $(BUILD_DIR)/$(TARGET)     - The asm.js JavaScript file"
+	@echo "  $(BUILD_DIR)/index.html    - Web interface"
+	@echo ""
+	@echo "Usage:"
+	@echo "  emmake make -f Makefile.web"
+	@echo "  or: make -f Makefile.web CC=emcc LD=emcc"
+
+.PHONY: all clean help

--- a/pico/draw.c
+++ b/pico/draw.c
@@ -1743,6 +1743,7 @@ PICO_INTERNAL void PicoFrameStart(void)
   int sprep = est->rendstatus & PDRAW_DIRTY_SPRITES;
   int skipped = est->rendstatus & PDRAW_SKIP_FRAME;
   int sync = est->rendstatus & (PDRAW_SYNC_NEEDED | PDRAW_SYNC_NEXT);
+  int prev_disp_on = est->rendstatus & PDRAW_DISP_WAS_ON;
 
   // prepare to do this frame
   est->rendstatus = 0;
@@ -1791,7 +1792,7 @@ PICO_INTERNAL void PicoFrameStart(void)
     est->rendstatus |= PDRAW_PARSE_SPRITES;
   if (est->Pico->video.reg[1] & 0x40)
     est->rendstatus |= PDRAW_DISP_WAS_ON;
-  else
+  else if (prev_disp_on)
     est->rendstatus |= PDRAW_DISP_OFF_START;
 
   est->HighCol = HighColBase + loffs * HighColIncrement;
@@ -1813,8 +1814,10 @@ static void DrawBlankedLine(int line, int offs, int sh, int bgc)
   int skip = skip_next_line;
 
   // Retain previous content for display-off lines before first enable (see PicoLine).
+  // Only when previous frame had display on (carryover, not intentional blank).
   // Not for 32X: FinalizeLine composites the 32X layer and must not be skipped.
-  if (!(est->rendstatus & PDRAW_DISP_WAS_ON) && !(PicoIn.AHW & PAHW_32X)) {
+  if ((est->rendstatus & PDRAW_DISP_OFF_START) &&
+      !(est->rendstatus & PDRAW_DISP_WAS_ON) && !(PicoIn.AHW & PAHW_32X)) {
     skip_next_line = 0;
     est->HighCol += HighColIncrement;
     est->DrawLineDest = (char *)est->DrawLineDest + DrawLineDestIncrement;
@@ -1851,8 +1854,10 @@ static void PicoLine(int line, int offs, int sh, int bgc, int off, int on)
   // If display is off and was never on this frame, retain previous frame's content.
   // This avoids blanking lines when display re-enable is delayed across a frame
   // boundary (e.g. Another World's multi-frame rendering cycle).
+  // Only when previous frame had display on (carryover, not intentional blank).
   // Not for 32X: FinalizeLine composites the 32X layer and must not be skipped.
   if (!(est->Pico->video.reg[1]&0x40) && !(off|on) &&
+      (est->rendstatus & PDRAW_DISP_OFF_START) &&
       !(est->rendstatus & PDRAW_DISP_WAS_ON) && !(PicoIn.AHW & PAHW_32X)) {
     skip_next_line = 0;
     est->HighCol += HighColIncrement;

--- a/pico/draw.c
+++ b/pico/draw.c
@@ -1789,6 +1789,10 @@ PICO_INTERNAL void PicoFrameStart(void)
     est->rendstatus |= PDRAW_SKIP_FRAME;
   if (sprep | skipped)
     est->rendstatus |= PDRAW_PARSE_SPRITES;
+  if (est->Pico->video.reg[1] & 0x40)
+    est->rendstatus |= PDRAW_DISP_WAS_ON;
+  else
+    est->rendstatus |= PDRAW_DISP_OFF_START;
 
   est->HighCol = HighColBase + loffs * HighColIncrement;
   est->DrawLineDest = (char *)DrawLineDestBase + loffs * DrawLineDestIncrement;
@@ -1807,6 +1811,15 @@ static void DrawBlankedLine(int line, int offs, int sh, int bgc)
 {
   struct PicoEState *est = &Pico.est;
   int skip = skip_next_line;
+
+  // Retain previous content for display-off lines before first enable (see PicoLine).
+  // Not for 32X: FinalizeLine composites the 32X layer and must not be skipped.
+  if (!(est->rendstatus & PDRAW_DISP_WAS_ON) && !(PicoIn.AHW & PAHW_32X)) {
+    skip_next_line = 0;
+    est->HighCol += HighColIncrement;
+    est->DrawLineDest = (char *)est->DrawLineDest + DrawLineDestIncrement;
+    return;
+  }
 
   if (PicoScanBegin != NULL && skip == 0)
     skip = PicoScanBegin(line + offs);
@@ -1834,6 +1847,19 @@ static void PicoLine(int line, int offs, int sh, int bgc, int off, int on)
   int skip = skip_next_line;
 
   est->DrawScanline = line;
+
+  // If display is off and was never on this frame, retain previous frame's content.
+  // This avoids blanking lines when display re-enable is delayed across a frame
+  // boundary (e.g. Another World's multi-frame rendering cycle).
+  // Not for 32X: FinalizeLine composites the 32X layer and must not be skipped.
+  if (!(est->Pico->video.reg[1]&0x40) && !(off|on) &&
+      !(est->rendstatus & PDRAW_DISP_WAS_ON) && !(PicoIn.AHW & PAHW_32X)) {
+    skip_next_line = 0;
+    est->HighCol += HighColIncrement;
+    est->DrawLineDest = (char *)est->DrawLineDest + DrawLineDestIncrement;
+    return;
+  }
+
   if (PicoScanBegin != NULL && skip == 0)
     skip = PicoScanBegin(line + offs);
 
@@ -1901,6 +1927,15 @@ void PicoDrawSync(int to, int off, int on)
   if (line <= to)
   {
     int width2 = (est->Pico->video.reg[12]&1) ? 160 : 128;
+
+    // For frames starting with display off, suppress partial blanking on the
+    // first display-enable line to retain previous frame's content there.
+    // Not for 32X: the 32X layer compositing must not be affected.
+    if ((est->rendstatus & PDRAW_DISP_OFF_START) && on && !off &&
+        !(PicoIn.AHW & PAHW_32X)) {
+      on = 0;
+      est->rendstatus &= ~PDRAW_DISP_OFF_START;
+    }
 
     if (unlikely(on|off) && (off >= width2 ||
           // hack for timing inaccuracy, if on/off near borders

--- a/pico/pico.h
+++ b/pico/pico.h
@@ -278,6 +278,8 @@ void PicoDoHighPal555(int sh, int line, struct PicoEState *est);
 #define PDRAW_SOFTSCALE    (1<<15) // H32 upscaling
 #define PDRAW_SYNC_NEEDED  (1<<16) // redraw needed
 #define PDRAW_SYNC_NEXT    (1<<17) // redraw next frame
+#define PDRAW_DISP_WAS_ON  (1<<18) // display was enabled at some point this frame
+#define PDRAW_DISP_OFF_START (1<<19) // display was off at frame start
 extern int rendstatus_old;
 extern int rendlines;
 

--- a/pico/videoport.c
+++ b/pico/videoport.c
@@ -969,6 +969,8 @@ PICO_INTERNAL_ASM void PicoVideoWrite(u32 a,unsigned short d)
           lineenabled = (d&0x40) ? Pico.m.scanline + !skip: -1;
           linedisabled = (d&0x40) ? -1 : Pico.m.scanline + !skip;
           lineoffset = (skip ? SekCyclesDone() - Pico.t.m68c_line_start : 0);
+          if (d&0x40)
+            Pico.est.rendstatus |= PDRAW_DISP_WAS_ON;
         } else if (num == 5 && pvid->reg[num] != d) {
           PicoVideoSync(InHblank(105)); // chaekopan
         } else if (((1<<num) & 0x738ff) && pvid->reg[num] != d)

--- a/platform/web/index.html
+++ b/platform/web/index.html
@@ -1,0 +1,1009 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>PicoDrive Web - Sega Genesis/Mega Drive Emulator</title>
+    <style>
+      * {
+          box-sizing: border-box;
+      }
+
+      body {
+          font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
+          background: linear-gradient(135deg, #1a1a2e 0%, #16213e 100%);
+          color: #e0e0e0;
+          margin: 0;
+          padding: 20px;
+          min-height: 100vh;
+      }
+
+      .container {
+          max-width: 900px;
+          margin: 0 auto;
+      }
+
+      h1 {
+          text-align: center;
+          color: #00d4ff;
+          margin-bottom: 10px;
+          text-shadow: 0 0 20px rgba(0, 212, 255, 0.3);
+      }
+
+      .subtitle {
+          text-align: center;
+          color: #888;
+          margin-bottom: 30px;
+      }
+
+      .game-area {
+          display: flex;
+          flex-direction: column;
+          align-items: center;
+          gap: 20px;
+      }
+
+      #canvas-container {
+          background: #000;
+          padding: 10px;
+          border-radius: 8px;
+          box-shadow: 0 0 30px rgba(0, 0, 0, 0.5);
+          /* Fixed container size to prevent layout shifts */
+          width: 660px;
+          height: 468px;
+          display: flex;
+          align-items: center;
+          justify-content: center;
+      }
+
+      #screen {
+          display: block;
+          image-rendering: pixelated;
+          image-rendering: crisp-edges;
+          background: #000;
+          /* Fixed display size - canvas scales to fit */
+          width: 640px;
+          height: 448px;
+      }
+
+      .controls-section {
+          width: 100%;
+          max-width: 640px;
+      }
+
+      .file-input-wrapper {
+          display: flex;
+          flex-wrap: wrap;
+          gap: 10px;
+          justify-content: center;
+          margin-bottom: 20px;
+      }
+
+      .btn {
+          padding: 12px 24px;
+          font-size: 14px;
+          font-weight: 600;
+          border: none;
+          border-radius: 6px;
+          cursor: pointer;
+          transition: all 0.2s ease;
+      }
+
+      .btn-primary {
+          background: linear-gradient(135deg, #00d4ff 0%, #0099cc 100%);
+          color: #000;
+      }
+
+      .btn-primary:hover:not(:disabled) {
+          transform: translateY(-2px);
+          box-shadow: 0 5px 20px rgba(0, 212, 255, 0.4);
+      }
+
+      .btn-secondary {
+          background: #333;
+          color: #fff;
+      }
+
+      .btn-secondary:hover:not(:disabled) {
+          background: #444;
+      }
+
+      .btn:disabled {
+          opacity: 0.5;
+          cursor: not-allowed;
+      }
+
+      #rom-input, #state-input {
+          display: none;
+      }
+
+      .game-info {
+          text-align: center;
+          margin: 10px 0;
+          min-height: 24px;
+      }
+
+      #status {
+          color: #888;
+          font-size: 14px;
+      }
+
+      .keyboard-help {
+          background: rgba(255, 255, 255, 0.05);
+          border-radius: 8px;
+          padding: 20px;
+          margin-top: 20px;
+      }
+
+      .keyboard-help h3 {
+          margin-top: 0;
+          color: #00d4ff;
+      }
+
+      .key-mappings {
+          display: grid;
+          grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+          gap: 10px;
+      }
+
+      .key-group {
+          background: rgba(0, 0, 0, 0.3);
+          padding: 15px;
+          border-radius: 6px;
+      }
+
+      .key-group h4 {
+          margin: 0 0 10px 0;
+          color: #aaa;
+          font-size: 12px;
+          text-transform: uppercase;
+      }
+
+      .key-item {
+          display: flex;
+          justify-content: space-between;
+          margin: 5px 0;
+          font-size: 14px;
+      }
+
+      .key-item .key {
+          background: #333;
+          padding: 2px 8px;
+          border-radius: 4px;
+          font-family: monospace;
+      }
+
+      .footer {
+          text-align: center;
+          margin-top: 30px;
+          color: #666;
+          font-size: 12px;
+      }
+
+      .footer a {
+          color: #00d4ff;
+          text-decoration: none;
+      }
+
+      @media (max-width: 700px) {
+          body {
+              padding: 10px;
+          }
+
+          #canvas-container {
+              width: calc(100vw - 20px);
+              height: auto;
+              aspect-ratio: 640 / 448;
+          }
+
+          #screen {
+              width: 100%;
+              height: 100%;
+          }
+      }
+    </style>
+  </head>
+  <body>
+    <div class="container">
+      <h1>PicoDrive Web</h1>
+      <p class="subtitle">Sega Genesis / Mega Drive / 32X Emulator</p>
+
+      <div class="game-area">
+        <div id="canvas-container">
+          <canvas id="screen" width="640" height="448"></canvas>
+        </div>
+
+        <div class="game-info">
+          <div id="status">Loading emulator...</div>
+        </div>
+
+        <div class="controls-section">
+          <div class="file-input-wrapper">
+            <input
+              type="file"
+              id="rom-input"
+              accept=".bin,.md,.gen,.smd,.32x,.sms,.gg"
+            >
+            <input type="file" id="state-input" accept=".state">
+            <button class="btn btn-primary" id="load-btn" disabled>Load ROM</button>
+            <button class="btn btn-secondary" id="reset-btn" disabled>Reset</button>
+            <button class="btn btn-secondary" id="save-state-btn" disabled>
+              Save State
+            </button>
+            <button class="btn btn-secondary" id="load-state-btn" disabled>
+              Load State
+            </button>
+          </div>
+        </div>
+
+        <div class="keyboard-help">
+          <h3>Keyboard Controls</h3>
+          <div class="key-mappings">
+            <div class="key-group">
+              <h4>Player 1 - D-Pad</h4>
+              <div class="key-item"><span>Up</span><span class="key">↑</span></div>
+              <div class="key-item"><span>Down</span><span class="key">↓</span></div>
+              <div class="key-item"><span>Left</span><span class="key">←</span></div>
+              <div class="key-item">
+                <span>Right</span><span class="key">→</span>
+              </div>
+            </div>
+            <div class="key-group">
+              <h4>Player 1 - Buttons</h4>
+              <div class="key-item"><span>A</span><span class="key">A</span></div>
+              <div class="key-item"><span>B</span><span class="key">S</span></div>
+              <div class="key-item"><span>C</span><span class="key">D</span></div>
+              <div class="key-item">
+                <span>Start</span><span class="key">Enter</span>
+              </div>
+            </div>
+            <div class="key-group">
+              <h4>Player 1 - 6-Button</h4>
+              <div class="key-item"><span>X</span><span class="key">Q</span></div>
+              <div class="key-item"><span>Y</span><span class="key">W</span></div>
+              <div class="key-item"><span>Z</span><span class="key">E</span></div>
+              <div class="key-item">
+                <span>Mode</span><span class="key">Shift</span>
+              </div>
+            </div>
+            <div class="key-group">
+              <h4>Player 2 - D-Pad</h4>
+              <div class="key-item"><span>Up</span><span class="key">I</span></div>
+              <div class="key-item"><span>Down</span><span class="key">K</span></div>
+              <div class="key-item"><span>Left</span><span class="key">J</span></div>
+              <div class="key-item">
+                <span>Right</span><span class="key">L</span>
+              </div>
+            </div>
+            <div class="key-group">
+              <h4>Player 2 - Buttons</h4>
+              <div class="key-item"><span>A</span><span class="key">B</span></div>
+              <div class="key-item"><span>B</span><span class="key">N</span></div>
+              <div class="key-item"><span>C</span><span class="key">M</span></div>
+              <div class="key-item">
+                <span>Start</span><span class="key">H</span>
+              </div>
+            </div>
+            <div class="key-group">
+              <h4>Player 2 - 6-Button</h4>
+              <div class="key-item"><span>X</span><span class="key">U</span></div>
+              <div class="key-item"><span>Y</span><span class="key">O</span></div>
+              <div class="key-item"><span>Z</span><span class="key">P</span></div>
+              <div class="key-item">
+                <span>Mode</span><span class="key">Ctrl</span>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+
+      <div class="footer">
+        <p>PicoDrive - Fast Sega 8/16 bit and 32X emulator</p>
+        <p>Supported formats: .bin, .md, .gen, .smd, .32x, .sms, .gg</p>
+      </div>
+    </div>
+
+    <script>
+      // Define Module BEFORE loading picodrive.js
+      var Module = {
+        onRuntimeInitialized: function () {
+          console.log("Emscripten runtime initialized, calling onPicoReady...")
+          window.picoRuntimeReady = true
+          if (typeof window.onPicoReady === "function") {
+            window.onPicoReady()
+          } else {
+            console.warn("onPicoReady not defined yet, will be called later")
+          }
+        },
+        print: function (text) {
+          console.log("stdout:", text)
+        },
+        printErr: function (text) {
+          console.error("stderr:", text)
+        },
+        onAbort: function (what) {
+          console.error("Emscripten aborted:", what)
+          document.getElementById("status").textContent = "Error: " + what
+        },
+      }
+      console.log("Module pre-defined")
+    </script>
+    <script src="picodrive.js"></script>
+    <script>
+      // PicoDrive Web Client
+      ;(function () {
+        "use strict"
+
+        // DOM elements
+        const canvas = document.getElementById("screen")
+        const ctx = canvas.getContext("2d")
+        const romInput = document.getElementById("rom-input")
+        const stateInput = document.getElementById("state-input")
+        const loadBtn = document.getElementById("load-btn")
+        const resetBtn = document.getElementById("reset-btn")
+        const saveStateBtn = document.getElementById("save-state-btn")
+        const loadStateBtn = document.getElementById("load-state-btn")
+        const status = document.getElementById("status")
+
+        // Emulator state
+        let emuReady = false
+        let gameLoaded = false
+        let running = false
+        let paused = false
+        let animFrameId = null
+        let currentRomFilename = ""
+
+        // Input state for both players
+        let inputState1 = 0
+        let inputState2 = 0
+
+        // Button mappings
+        let BTN_UP
+        let BTN_DOWN
+        let BTN_LEFT
+        let BTN_RIGHT
+        let BTN_A
+        let BTN_B
+        let BTN_C
+        let BTN_X
+        let BTN_Y
+        let BTN_Z
+        let BTN_START
+        let BTN_MODE
+
+        // Emscripten functions
+        let _pico_init
+        let _pico_get_rom_buffer
+        let _pico_load_rom
+        let _pico_reset
+        let _pico_set_input
+        let _pico_run_frame
+        let _pico_get_video_buffer
+        let _pico_get_video_width
+        let _pico_get_video_height
+        let _pico_state_save
+        let _pico_state_load
+        let _pico_get_state_buffer
+        let _pico_get_state_size
+        let _pico_get_state_load_buffer
+        let _pico_is_pal
+
+        // Video
+        let videoWidth = 320
+        let videoHeight = 224
+        let imageData = null
+
+        // Offscreen canvas for rendering at native resolution
+        let offscreenCanvas = document.createElement("canvas")
+        let offscreenCtx = offscreenCanvas.getContext("2d")
+
+        // Frame timing
+        let lastFrameTime = 0
+        let frameAccumulator = 0
+        let targetFrameTime = 1000 / 60 // Default NTSC (will be updated)
+
+        // Audio
+        let audioCtx = null
+        const SAMPLE_RATE = 44100
+        const MAX_AUDIO_LAG = 0.1 // 100ms max latency
+        let nextAudioTime = 0
+
+        // Initialize audio context on user interaction
+        function initAudio() {
+          if (audioCtx) {
+            return
+          }
+
+          try {
+            audioCtx = new (window.AudioContext || window.webkitAudioContext)({
+              sampleRate: SAMPLE_RATE,
+            })
+            nextAudioTime = 0
+            console.log(
+              "Audio context initialized, sample rate:",
+              audioCtx.sampleRate
+            )
+          } catch (e) {
+            console.warn("Failed to initialize audio:", e)
+          }
+        }
+
+        // Audio write callback (called from Emscripten)
+        window.onAudioWrite = function (audioData) {
+          if (!audioCtx || audioCtx.state !== "running") {
+            return
+          }
+
+          const samples = audioData.length / 2
+          const buffer = audioCtx.createBuffer(2, samples, SAMPLE_RATE)
+          const left = buffer.getChannelData(0)
+          const right = buffer.getChannelData(1)
+
+          for (let i = 0; i < samples; i++) {
+            left[i] = audioData[i * 2] / 32768
+            right[i] = audioData[i * 2 + 1] / 32768
+          }
+
+          const currentTime = audioCtx.currentTime
+
+          // If we"ve fallen too far behind, reset the schedule
+          if (nextAudioTime < currentTime) {
+            nextAudioTime = currentTime
+          }
+
+          // If we"re too far ahead (more than 100ms), skip this buffer to reduce latency
+          if (nextAudioTime > currentTime + MAX_AUDIO_LAG) {
+            return
+          }
+
+          const source = audioCtx.createBufferSource()
+          source.buffer = buffer
+          source.connect(audioCtx.destination)
+          source.start(nextAudioTime)
+
+          // Schedule next buffer right after this one
+          nextAudioTime = nextAudioTime + buffer.duration
+        }
+
+        // Video mode change callback
+        window.onVideoModeChange = function (width, height) {
+          videoWidth = width
+          videoHeight = height
+          // Set up offscreen canvas at native resolution
+          offscreenCanvas.width = width
+          offscreenCanvas.height = height
+          imageData = offscreenCtx.createImageData(width, height)
+          // Set canvas to native resolution (CSS handles scaling)
+          canvas.width = width
+          canvas.height = height
+          console.log("Video mode changed:", width, "x", height)
+        }
+
+        // Error callback
+        window.onPicoError = function (msg) {
+          status.textContent = "Error: " + msg
+          status.style.color = "#ff4444"
+        }
+
+        // Called when Emscripten runtime is ready
+        window.onPicoReady = function () {
+          console.log("PicoDrive ready")
+
+          // Wrap functions
+          _pico_init = Module.cwrap("pico_init", "number", [])
+          _pico_get_rom_buffer = Module.cwrap("pico_get_rom_buffer", "number", [
+            "number",
+          ])
+          _pico_load_rom = Module.cwrap("pico_load_rom", "number", ["string"])
+          _pico_reset = Module.cwrap("pico_reset", null, [])
+          _pico_set_input = Module.cwrap("pico_set_input", null, [
+            "number",
+            "number",
+          ])
+          _pico_run_frame = Module.cwrap("pico_run_frame", null, [])
+          _pico_get_video_buffer = Module.cwrap(
+            "pico_get_video_buffer",
+            "number",
+            []
+          )
+          _pico_get_video_width = Module.cwrap("pico_get_video_width", "number", [])
+          _pico_get_video_height = Module.cwrap(
+            "pico_get_video_height",
+            "number",
+            []
+          )
+          _pico_is_pal = Module.cwrap("pico_is_pal", "number", [])
+          _pico_state_save = Module.cwrap("pico_state_save", "number", [])
+          _pico_state_load = Module.cwrap("pico_state_load", "number", [])
+          _pico_get_state_buffer = Module.cwrap(
+            "pico_get_state_buffer",
+            "number",
+            []
+          )
+          _pico_get_state_size = Module.cwrap("pico_get_state_size", "number", [])
+          _pico_get_state_load_buffer = Module.cwrap(
+            "pico_get_state_load_buffer",
+            "number",
+            ["number"]
+          )
+
+          // Get button constants
+          BTN_UP = Module.ccall("pico_get_button_up", "number", [], [])
+          BTN_DOWN = Module.ccall("pico_get_button_down", "number", [], [])
+          BTN_LEFT = Module.ccall("pico_get_button_left", "number", [], [])
+          BTN_RIGHT = Module.ccall("pico_get_button_right", "number", [], [])
+          BTN_B = Module.ccall("pico_get_button_b", "number", [], [])
+          BTN_C = Module.ccall("pico_get_button_c", "number", [], [])
+          BTN_A = Module.ccall("pico_get_button_a", "number", [], [])
+          BTN_START = Module.ccall("pico_get_button_start", "number", [], [])
+          BTN_Z = Module.ccall("pico_get_button_z", "number", [], [])
+          BTN_Y = Module.ccall("pico_get_button_y", "number", [], [])
+          BTN_X = Module.ccall("pico_get_button_x", "number", [], [])
+          BTN_MODE = Module.ccall("pico_get_button_mode", "number", [], [])
+
+          // Initialize emulator
+          if (_pico_init()) {
+            emuReady = true
+            loadBtn.disabled = false
+            status.textContent = "Ready - Select a ROM file to play"
+            status.style.color = "#88ff88"
+          } else {
+            status.textContent = "Failed to initialize emulator"
+            status.style.color = "#ff4444"
+          }
+
+          // Initialize video
+          videoWidth = _pico_get_video_width()
+          videoHeight = _pico_get_video_height()
+          // Set up offscreen canvas at native resolution
+          offscreenCanvas.width = videoWidth
+          offscreenCanvas.height = videoHeight
+          imageData = offscreenCtx.createImageData(videoWidth, videoHeight)
+          // Set canvas to native resolution (CSS handles scaling)
+          canvas.width = videoWidth
+          canvas.height = videoHeight
+        }
+
+        // Load ROM from file
+        function loadROM(file) {
+          if (!emuReady) {
+            return
+          }
+
+          initAudio()
+
+          const reader = new FileReader()
+          reader.onload = function (e) {
+            const data = new Uint8Array(e.target.result)
+            const size = data.length
+
+            status.textContent = "Loading ROM..."
+
+            // Get buffer pointer and copy ROM data
+            const bufPtr = _pico_get_rom_buffer(size)
+            if (!bufPtr) {
+              status.textContent = "Failed to allocate ROM buffer"
+              status.style.color = "#ff4444"
+              return
+            }
+
+            // Copy ROM data to Emscripten heap
+            Module.HEAPU8.set(data, bufPtr)
+
+            // Load the ROM (region auto-detected from ROM header)
+            if (_pico_load_rom(file.name)) {
+              gameLoaded = true
+              running = true
+              paused = false
+              currentRomFilename = file.name
+
+              // Update UI
+              resetBtn.disabled = false
+              saveStateBtn.disabled = false
+              loadStateBtn.disabled = false
+              loadBtn.blur()
+
+              const isPal = _pico_is_pal()
+              status.textContent =
+                "Running (" + (isPal ? "PAL 50Hz" : "NTSC 60Hz") + ")"
+              status.style.color = "#88ff88"
+
+              // Set frame timing based on region
+              targetFrameTime = isPal ? 1000 / 50 : 1000 / 60
+              lastFrameTime = performance.now()
+              frameAccumulator = 0
+              console.log(
+                "Frame timing:",
+                isPal ? "50Hz PAL" : "60Hz NTSC",
+                "targetFrameTime:",
+                targetFrameTime.toFixed(2),
+                "ms"
+              )
+
+              // Start emulation loop
+              if (animFrameId) {
+                cancelAnimationFrame(animFrameId)
+              }
+              runFrame(performance.now())
+            } else {
+              status.textContent = "Failed to load ROM"
+              status.style.color = "#ff4444"
+            }
+          }
+          reader.readAsArrayBuffer(file)
+        }
+
+        // Render frame to canvas
+        function renderFrame() {
+          const bufPtr = _pico_get_video_buffer()
+          const width = _pico_get_video_width()
+          const height = _pico_get_video_height()
+
+          if (width !== videoWidth || height !== videoHeight || !imageData) {
+            videoWidth = width
+            videoHeight = height
+            // Set up offscreen canvas at native resolution
+            offscreenCanvas.width = width
+            offscreenCanvas.height = height
+            imageData = offscreenCtx.createImageData(width, height)
+            // Set canvas to native resolution (CSS handles scaling)
+            canvas.width = width
+            canvas.height = height
+            console.log("Video mode:", width, "x", height)
+          }
+
+          // Convert RGB565 to RGBA
+          const pixels = imageData.data
+          const heap = Module.HEAPU16
+          const base = bufPtr >> 1
+
+          for (let y = 0; y < height; y++) {
+            for (let x = 0; x < width; x++) {
+              // Buffer pitch matches width (same as libretro)
+              const srcIdx = base + y * width + x
+              const dstIdx = (y * width + x) * 4
+
+              const pixel = heap[srcIdx]
+
+              // RGB565 to RGB888 (5-6-5 bits)
+              const r = ((pixel >> 11) & 0x1f) << 3
+              const g = ((pixel >> 5) & 0x3f) << 2
+              const b = (pixel & 0x1f) << 3
+
+              pixels[dstIdx] = r
+              pixels[dstIdx + 1] = g
+              pixels[dstIdx + 2] = b
+              pixels[dstIdx + 3] = 255
+            }
+          }
+
+          // Draw to offscreen canvas first, then scale to display
+          offscreenCtx.putImageData(imageData, 0, 0)
+          ctx.imageSmoothingEnabled = false
+          ctx.drawImage(
+            offscreenCanvas,
+            0,
+            0,
+            width,
+            height,
+            0,
+            0,
+            canvas.width,
+            canvas.height
+          )
+        }
+
+        // Main emulation loop
+        function runFrame(currentTime) {
+          if (!running || paused) {
+            animFrameId = null
+            return
+          }
+
+          // Calculate elapsed time
+          const deltaTime = currentTime - lastFrameTime
+          lastFrameTime = currentTime
+
+          // Accumulate time (cap at 100ms to prevent spiral of death)
+          frameAccumulator = frameAccumulator + Math.min(deltaTime, 100)
+
+          // Run emulation frames at correct rate
+          let framesRun = 0
+          while (frameAccumulator >= targetFrameTime && framesRun < 3) {
+            // Set input for both players
+            _pico_set_input(0, inputState1)
+            _pico_set_input(1, inputState2)
+
+            // Run one frame
+            _pico_run_frame()
+
+            frameAccumulator = frameAccumulator - targetFrameTime
+            framesRun = framesRun + 1
+          }
+
+          // Render only if we ran at least one frame
+          if (framesRun > 0) {
+            renderFrame()
+          }
+
+          // Schedule next frame
+          animFrameId = requestAnimationFrame(runFrame)
+        }
+
+        // Keyboard handling - Player 1 and Player 2 key mappings
+        const keyMapPlayer1 = {
+          ArrowUp: "UP",
+          ArrowDown: "DOWN",
+          ArrowLeft: "LEFT",
+          ArrowRight: "RIGHT",
+          Enter: "START",
+          KeyA: "A",
+          KeyS: "B",
+          KeyD: "C",
+          KeyQ: "X",
+          KeyW: "Y",
+          KeyE: "Z",
+          ShiftLeft: "MODE",
+          ShiftRight: "MODE",
+        }
+
+        const keyMapPlayer2 = {
+          KeyI: "UP",
+          KeyK: "DOWN",
+          KeyJ: "LEFT",
+          KeyL: "RIGHT",
+          KeyH: "START",
+          KeyB: "A",
+          KeyN: "B",
+          KeyM: "C",
+          KeyU: "X",
+          KeyO: "Y",
+          KeyP: "Z",
+          ControlLeft: "MODE",
+          ControlRight: "MODE",
+        }
+
+        function actionToButton(action) {
+          switch (action) {
+            case "UP":
+              return BTN_UP
+            case "DOWN":
+              return BTN_DOWN
+            case "LEFT":
+              return BTN_LEFT
+            case "RIGHT":
+              return BTN_RIGHT
+            case "A":
+              return BTN_A
+            case "B":
+              return BTN_B
+            case "C":
+              return BTN_C
+            case "START":
+              return BTN_START
+            case "X":
+              return BTN_X
+            case "Y":
+              return BTN_Y
+            case "Z":
+              return BTN_Z
+            case "MODE":
+              return BTN_MODE
+            default:
+              return 0
+          }
+        }
+
+        function updateInput(code, pressed) {
+          // Check Player 1
+          const action1 = keyMapPlayer1[code]
+          if (action1) {
+            const btn = actionToButton(action1)
+            if (pressed) {
+              inputState1 |= btn
+            } else {
+              inputState1 &= ~btn
+            }
+          }
+
+          // Check Player 2
+          const action2 = keyMapPlayer2[code]
+          if (action2) {
+            const btn = actionToButton(action2)
+            if (pressed) {
+              inputState2 |= btn
+            } else {
+              inputState2 &= ~btn
+            }
+          }
+        }
+
+        function isGameKey(code) {
+          return keyMapPlayer1[code] || keyMapPlayer2[code]
+        }
+
+        document.addEventListener("keydown", function (e) {
+          if (isGameKey(e.code)) {
+            e.preventDefault()
+            updateInput(e.code, true)
+          }
+        })
+
+        document.addEventListener("keyup", function (e) {
+          if (isGameKey(e.code)) {
+            e.preventDefault()
+            updateInput(e.code, false)
+          }
+        })
+
+        // Button handlers
+        loadBtn.addEventListener("click", function () {
+          romInput.click()
+        })
+
+        romInput.addEventListener("change", function (e) {
+          if (e.target.files.length > 0) {
+            loadROM(e.target.files[0])
+          }
+        })
+
+        resetBtn.addEventListener("click", function () {
+          if (gameLoaded) {
+            _pico_reset()
+            if (!running) {
+              running = true
+              paused = false
+              status.textContent = "Running"
+              runFrame()
+            }
+          }
+        })
+
+        saveStateBtn.addEventListener("click", function () {
+          if (gameLoaded) {
+            if (_pico_state_save()) {
+              // Get the state data from emscripten memory
+              const statePtr = _pico_get_state_buffer()
+              const stateSize = _pico_get_state_size()
+
+              if (statePtr && stateSize > 0) {
+                // Copy data from emscripten heap
+                const stateData = new Uint8Array(
+                  Module.HEAPU8.buffer,
+                  statePtr,
+                  stateSize
+                )
+                const blob = new Blob([stateData], {
+                  type: "application/octet-stream",
+                })
+
+                // Create download link
+                const url = URL.createObjectURL(blob)
+                const a = document.createElement("a")
+                a.href = url
+
+                // Use ROM filename (without extension) for state filename
+                const baseName =
+                  currentRomFilename.replace(/\.[^/.]+$/, "") || "game"
+                a.download = baseName + ".state"
+
+                // Trigger download
+                document.body.appendChild(a)
+                a.click()
+                document.body.removeChild(a)
+                URL.revokeObjectURL(url)
+
+                status.textContent = "State saved to file"
+                status.style.color = "#88ff88"
+              } else {
+                status.textContent = "Failed to get state data"
+                status.style.color = "#ff4444"
+              }
+            } else {
+              status.textContent = "Failed to save state"
+              status.style.color = "#ff4444"
+            }
+          }
+        })
+
+        loadStateBtn.addEventListener("click", function () {
+          if (gameLoaded) {
+            stateInput.click()
+          }
+        })
+
+        stateInput.addEventListener("change", function (e) {
+          if (e.target.files.length > 0 && gameLoaded) {
+            const file = e.target.files[0]
+            const reader = new FileReader()
+
+            reader.onload = function (event) {
+              const data = new Uint8Array(event.target.result)
+              const size = data.length
+
+              // Get buffer to write state data
+              const bufPtr = _pico_get_state_load_buffer(size)
+              if (!bufPtr) {
+                status.textContent = "Failed to allocate state buffer"
+                status.style.color = "#ff4444"
+                return
+              }
+
+              // Copy state data to emscripten heap
+              Module.HEAPU8.set(data, bufPtr)
+
+              // Load the state
+              if (_pico_state_load()) {
+                status.textContent = "State loaded from file"
+                status.style.color = "#88ff88"
+              } else {
+                status.textContent = "Failed to load state"
+                status.style.color = "#ff4444"
+              }
+            }
+
+            reader.readAsArrayBuffer(file)
+          }
+          // Reset the input so the same file can be loaded again
+          stateInput.value = ""
+        })
+
+        // Drag and drop support
+        canvas.addEventListener("dragover", function (e) {
+          e.preventDefault()
+          e.dataTransfer.dropEffect = "copy"
+        })
+
+        canvas.addEventListener("drop", function (e) {
+          e.preventDefault()
+          if (e.dataTransfer.files.length > 0) {
+            loadROM(e.dataTransfer.files[0])
+          }
+        })
+
+        // Pause emulation when page loses focus, resume when it regains focus
+        function pauseEmulation() {
+          if (gameLoaded && running && !paused) {
+            paused = true
+            status.textContent = "Paused (window inactive)"
+          }
+        }
+
+        function resumeEmulation() {
+          if (gameLoaded && running && paused) {
+            paused = false
+            const isPal = _pico_is_pal()
+            status.textContent =
+              "Running (" + (isPal ? "PAL 50Hz" : "NTSC 60Hz") + ")"
+            // Reset frame timing to prevent catching up
+            lastFrameTime = performance.now()
+            frameAccumulator = 0
+            runFrame(performance.now())
+          }
+        }
+
+        // Handle page visibility changes (tab switching)
+        document.addEventListener("visibilitychange", function () {
+          if (document.hidden) {
+            pauseEmulation()
+          } else {
+            resumeEmulation()
+          }
+        })
+
+        // Handle window focus/blur
+        window.addEventListener("blur", pauseEmulation)
+        window.addEventListener("focus", resumeEmulation)
+
+        // Initial status
+        status.textContent = "Loading emulator..."
+
+        // Check if runtime was already initialized before our code ran
+        if (window.picoRuntimeReady && !emuReady) {
+          console.log("Runtime was already ready, initializing now...")
+          window.onPicoReady()
+        }
+      })()
+    </script>
+  </body>
+</html>

--- a/platform/web/index.html
+++ b/platform/web/index.html
@@ -446,14 +446,12 @@
 
           const currentTime = audioCtx.currentTime
 
-          // If we"ve fallen too far behind, reset the schedule
-          if (nextAudioTime < currentTime) {
-            nextAudioTime = currentTime
-          }
-
-          // If we"re too far ahead (more than 100ms), skip this buffer to reduce latency
-          if (nextAudioTime > currentTime + MAX_AUDIO_LAG) {
-            return
+          const AUDIO_MAX_AHEAD = 0.15 // resync if audio drifts more than 150ms ahead
+          if (
+            nextAudioTime < currentTime ||
+            nextAudioTime > currentTime + AUDIO_MAX_AHEAD
+          ) {
+            nextAudioTime = currentTime + MAX_AUDIO_LAG
           }
 
           const source = audioCtx.createBufferSource()

--- a/platform/web/web.c
+++ b/platform/web/web.c
@@ -1,0 +1,694 @@
+/*
+ * PicoDrive Web Platform Layer
+ * Emscripten/asm.js interface for running in browser
+ */
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <stdarg.h>
+
+#ifdef __EMSCRIPTEN__
+#include <emscripten.h>
+#endif
+
+#include <pico/pico_types.h>
+#include <pico/pico.h>
+#include <pico/pico_int.h>
+#include <pico/state.h>
+
+/* Video output buffer - RGB565 format */
+/* Use fixed 320x240 buffer, same as libretro */
+#define VOUT_MAX_WIDTH 320
+#define VOUT_MAX_HEIGHT 240
+
+static unsigned short vout_buf[VOUT_MAX_WIDTH * VOUT_MAX_HEIGHT];
+static int vout_width = VOUT_MAX_WIDTH;
+static int vout_height = VOUT_MAX_HEIGHT;
+static int vout_offset = 0;  /* Byte offset for start_line */
+
+/* Store current video mode parameters for mode changes */
+static int vm_current_start_line = -1;
+static int vm_current_line_count = -1;
+static int vm_current_start_col = -1;
+static int vm_current_col_count = -1;
+
+/* Audio output buffer */
+#define SND_RATE 44100
+#define SND_MAX_SAMPLES (SND_RATE / 50 * 2)  /* stereo, 50fps minimum */
+static short snd_buffer[SND_MAX_SAMPLES * 2];
+
+/* Input state - Genesis/MD format: MXYZ SACB RLDU */
+static unsigned short input_state[2] = {0, 0};
+
+/* ROM data */
+static unsigned char *rom_data = NULL;
+static unsigned int rom_size = 0;
+
+/* Emulator state */
+static int emu_initialized = 0;
+static int game_loaded = 0;
+
+/* Platform functions required by PicoDrive core */
+
+void lprintf(const char *fmt, ...)
+{
+    va_list vl;
+    va_start(vl, fmt);
+#ifdef __EMSCRIPTEN__
+    char buf[512];
+    vsnprintf(buf, sizeof(buf), fmt, vl);
+    EM_ASM({
+        console.log(UTF8ToString($0));
+    }, buf);
+#else
+    vprintf(fmt, vl);
+#endif
+    va_end(vl);
+}
+
+/* Dummy MP3 functions - not supported in web build */
+int mp3_get_bitrate(void *f, int size) { return 0; }
+void mp3_start_play(void *f, int pos) {}
+void mp3_update(int *buffer, int length, int stereo) {}
+
+/* Dummy OGG functions - not supported in web build (needs libvorbis) */
+int ogg_get_length(void *f) { return 0; }
+void ogg_start_play(void *f, int sample_offset) {}
+void ogg_stop_play(void) {}
+void ogg_update(int *buffer, int length, int stereo) {}
+
+/* Cache flush - not needed for web */
+void cache_flush_d_inval_i(void *start_addr, void *end_addr) {}
+
+/* Memory allocation */
+void *plat_mmap(unsigned long addr, size_t size, int need_exec, int is_fixed)
+{
+    void *ret = calloc(1, size);
+    return ret;
+}
+
+void *plat_mremap(void *ptr, size_t oldsize, size_t newsize)
+{
+    void *ret = realloc(ptr, newsize);
+    return ret;
+}
+
+void plat_munmap(void *ptr, size_t size)
+{
+    if (ptr)
+        free(ptr);
+}
+
+void *plat_mem_get_for_drc(size_t size)
+{
+    return NULL;  /* No DRC in web build */
+}
+
+int plat_mem_set_exec(void *ptr, size_t size)
+{
+    return 0;
+}
+
+/* Video mode change callback - called by the core when video mode changes */
+void emu_video_mode_change(int start_line, int line_count, int start_col, int col_count)
+{
+    /* Store current video mode for 32X startup re-init */
+    vm_current_start_line = start_line;
+    vm_current_line_count = line_count;
+    vm_current_start_col = start_col;
+    vm_current_col_count = col_count;
+
+    /* Match libretro exactly */
+    vout_width = col_count;
+    vout_height = line_count;
+
+    /* Clear the entire buffer */
+    memset(vout_buf, 0, VOUT_MAX_WIDTH * VOUT_MAX_HEIGHT * 2);
+
+    /* Set output buffer - use vout_width * 2 as pitch (same as libretro) */
+    PicoDrawSetOutBuf(vout_buf, vout_width * 2);
+
+    /* Calculate offset to where visible content starts (same as libretro) */
+    vout_offset = vout_width * start_line * 2;
+
+    /* Sanity checks (same as libretro) */
+    if (vout_height > VOUT_MAX_HEIGHT)
+        vout_height = VOUT_MAX_HEIGHT;
+    if (vout_offset > vout_width * (VOUT_MAX_HEIGHT - 1) * 2)
+        vout_offset = vout_width * (VOUT_MAX_HEIGHT - 1) * 2;
+
+#ifdef __EMSCRIPTEN__
+    EM_ASM({
+        if (typeof window.onVideoModeChange === 'function') {
+            window.onVideoModeChange($0, $1);
+        }
+    }, vout_width, vout_height);
+#endif
+
+    /* Force palette refresh */
+    Pico.m.dirtyPal = 1;
+}
+
+/* 32X startup callback */
+void emu_32x_startup(void)
+{
+    /* Match libretro: use_32x_line_mode=0 for 32X */
+    PicoDrawSetOutFormat(PDF_RGB555, 0);
+
+    /* Re-apply video mode change if we have valid mode info */
+    if ((vm_current_start_line != -1) && (vm_current_line_count != -1) &&
+        (vm_current_start_col != -1) && (vm_current_col_count != -1)) {
+        emu_video_mode_change(vm_current_start_line, vm_current_line_count,
+                              vm_current_start_col, vm_current_col_count);
+    } else {
+        PicoDrawSetOutBuf(vout_buf, vout_width * 2);
+    }
+}
+
+/* Audio write callback */
+static void snd_write(int len)
+{
+#ifdef __EMSCRIPTEN__
+    /* len is in bytes, we have 16-bit stereo samples */
+    int samples = len / 4;
+    EM_ASM({
+        if (typeof window.onAudioWrite === 'function') {
+            var ptr = $0;
+            var samples = $1;
+            var audioData = new Int16Array(samples * 2);
+            for (var i = 0; i < samples * 2; i++) {
+                audioData[i] = HEAP16[(ptr >> 1) + i];
+            }
+            window.onAudioWrite(audioData);
+        }
+    }, PicoIn.sndOut, samples);
+#endif
+}
+
+/* ========== Exported API ========== */
+
+#ifdef __EMSCRIPTEN__
+EMSCRIPTEN_KEEPALIVE
+#endif
+int pico_init(void)
+{
+    if (emu_initialized)
+        return 1;
+
+    /* Initialize emulator */
+    PicoInit();
+
+    /* Configure default options - enable all features */
+    PicoIn.opt = POPT_EN_STEREO | POPT_EN_FM | POPT_EN_PSG | POPT_EN_Z80 |
+                 POPT_EN_MCD_PCM | POPT_EN_MCD_CDDA | POPT_EN_MCD_GFX |
+                 POPT_ACC_SPRITES | POPT_EN_32X | POPT_EN_PWM |
+                 POPT_DIS_32C_BORDER;  /* Disable 32-column border for proper rendering */
+
+    /* Auto-detect region from ROM header (like all other emulators) */
+    PicoIn.regionOverride = 0;  /* 0 = auto-detect from ROM */
+    /* Region priority when ROM supports multiple regions: US, EU, JP */
+    PicoIn.autoRgnOrder = 0x184;
+
+    /* Setup audio */
+    PicoIn.sndRate = SND_RATE;
+    PicoIn.sndOut = snd_buffer;
+    PicoIn.writeSound = snd_write;
+
+    /* Setup video - use accurate renderer with RGB555 output */
+    PicoDrawSetOutFormat(PDF_RGB555, 0);
+    PicoDrawSetOutBuf(vout_buf, vout_width * 2);
+
+    /* Setup input - 6 button pad for both players */
+    PicoSetInputDevice(0, PICO_INPUT_PAD_6BTN);
+    PicoSetInputDevice(1, PICO_INPUT_PAD_6BTN);
+
+    emu_initialized = 1;
+
+    return 1;
+}
+
+#ifdef __EMSCRIPTEN__
+EMSCRIPTEN_KEEPALIVE
+#endif
+void pico_exit(void)
+{
+    if (!emu_initialized)
+        return;
+
+    if (rom_data) {
+        free(rom_data);
+        rom_data = NULL;
+        rom_size = 0;
+    }
+
+    PicoExit();
+    emu_initialized = 0;
+    game_loaded = 0;
+}
+
+#ifdef __EMSCRIPTEN__
+EMSCRIPTEN_KEEPALIVE
+#endif
+unsigned char *pico_get_rom_buffer(unsigned int size)
+{
+    /* Allocate or reallocate ROM buffer */
+    if (rom_data) {
+        free(rom_data);
+    }
+
+    rom_data = (unsigned char *)malloc(size);
+    rom_size = size;
+
+    return rom_data;
+}
+
+#ifdef __EMSCRIPTEN__
+EMSCRIPTEN_KEEPALIVE
+#endif
+int pico_load_rom(const char *filename)
+{
+    if (!emu_initialized) {
+        return 0;
+    }
+
+    if (!rom_data || rom_size == 0) {
+        return 0;
+    }
+
+    /* Unload previous game if any */
+    if (game_loaded) {
+        PicoCartUnload();
+        game_loaded = 0;
+    }
+
+    /* Load the ROM
+     * Note: Pass empty string for carthw_cfg so that parse_carthw() gets called
+     * and uses the built-in carthw database for SVP/special hardware detection */
+    enum media_type_e media_type = PicoLoadMedia(filename, rom_data, rom_size,
+                                                  "", NULL, NULL, NULL);
+
+    if (media_type <= 0) {
+        return 0;
+    }
+
+    /* Prepare emulation loop (PicoLoadMedia already called PicoPower internally) */
+    PicoLoopPrepare();
+
+    /* Initialize sound for the detected region (PAL/NTSC) */
+    memset(snd_buffer, 0, sizeof(snd_buffer));
+    PsndRerate(0);
+
+    /* Apply renderer - match libretro's apply_renderer() */
+    PicoIn.opt &= ~(POPT_ALT_RENDERER | POPT_EN_SOFTSCALE);
+    PicoIn.opt |= POPT_DIS_32C_BORDER;
+    /* Match libretro: always use_32x_line_mode=0 */
+    PicoDrawSetOutFormat(PDF_RGB555, 0);
+    PicoDrawSetOutBuf(vout_buf, vout_width * 2);
+
+    game_loaded = 1;
+
+    /* Force 32X startup for .32x ROM files */
+    if ((PicoIn.opt & POPT_EN_32X) && !(PicoIn.AHW & PAHW_32X)) {
+        /* Check if filename ends with .32x (case insensitive) */
+        int len = strlen(filename);
+        if (len >= 4) {
+            const char *ext = filename + len - 4;
+            if ((ext[0] == '.' || ext[0] == '.') &&
+                (ext[1] == '3') &&
+                (ext[2] == '2') &&
+                (ext[3] == 'x' || ext[3] == 'X')) {
+                Pico32xStartup();
+
+                /* Reset SH2 processors to read PC/SP from HLE BIOS */
+                p32x_reset_sh2s();
+            }
+        }
+    }
+
+    return 1;
+}
+
+#ifdef __EMSCRIPTEN__
+EMSCRIPTEN_KEEPALIVE
+#endif
+void pico_reset(void)
+{
+    if (game_loaded) {
+        PicoReset();
+    }
+}
+
+#ifdef __EMSCRIPTEN__
+EMSCRIPTEN_KEEPALIVE
+#endif
+void pico_set_input(int pad, unsigned short buttons)
+{
+    if (pad >= 0 && pad < 2) {
+        input_state[pad] = buttons;
+    }
+}
+
+#ifdef __EMSCRIPTEN__
+EMSCRIPTEN_KEEPALIVE
+#endif
+static int frame_count = 0;
+
+void pico_run_frame(void)
+{
+    if (!game_loaded)
+        return;
+
+    /* Update input */
+    PicoIn.pad[0] = input_state[0];
+    PicoIn.pad[1] = input_state[1];
+
+    /* Run one frame */
+    PicoFrame();
+
+    frame_count++;
+}
+
+#ifdef __EMSCRIPTEN__
+EMSCRIPTEN_KEEPALIVE
+#endif
+unsigned short *pico_get_video_buffer(void)
+{
+    /* Return pointer to visible area (with offset for start_line) */
+    return (unsigned short *)((char *)vout_buf + vout_offset);
+}
+
+#ifdef __EMSCRIPTEN__
+EMSCRIPTEN_KEEPALIVE
+#endif
+int pico_get_video_width(void)
+{
+    return vout_width;
+}
+
+#ifdef __EMSCRIPTEN__
+EMSCRIPTEN_KEEPALIVE
+#endif
+int pico_get_video_height(void)
+{
+    return vout_height;
+}
+
+#ifdef __EMSCRIPTEN__
+EMSCRIPTEN_KEEPALIVE
+#endif
+int pico_is_pal(void)
+{
+    return Pico.m.pal;
+}
+
+#ifdef __EMSCRIPTEN__
+EMSCRIPTEN_KEEPALIVE
+#endif
+const char *pico_get_rom_name(void)
+{
+    if (!game_loaded)
+        return "";
+
+    /* Return the game name from the ROM header */
+    static char name[49];
+    memcpy(name, media_id_header + 0x20, 48);
+    name[48] = '\0';
+
+    /* Trim trailing spaces */
+    int i;
+    for (i = 47; i >= 0 && name[i] == ' '; i--)
+        name[i] = '\0';
+
+    return name;
+}
+
+/* Input button definitions for JavaScript */
+#ifdef __EMSCRIPTEN__
+EMSCRIPTEN_KEEPALIVE
+#endif
+int pico_get_button_up(void)    { return 1 << 0; }  /* GBTN_UP */
+
+#ifdef __EMSCRIPTEN__
+EMSCRIPTEN_KEEPALIVE
+#endif
+int pico_get_button_down(void)  { return 1 << 1; }  /* GBTN_DOWN */
+
+#ifdef __EMSCRIPTEN__
+EMSCRIPTEN_KEEPALIVE
+#endif
+int pico_get_button_left(void)  { return 1 << 2; }  /* GBTN_LEFT */
+
+#ifdef __EMSCRIPTEN__
+EMSCRIPTEN_KEEPALIVE
+#endif
+int pico_get_button_right(void) { return 1 << 3; }  /* GBTN_RIGHT */
+
+#ifdef __EMSCRIPTEN__
+EMSCRIPTEN_KEEPALIVE
+#endif
+int pico_get_button_b(void)     { return 1 << 4; }  /* GBTN_B */
+
+#ifdef __EMSCRIPTEN__
+EMSCRIPTEN_KEEPALIVE
+#endif
+int pico_get_button_c(void)     { return 1 << 5; }  /* GBTN_C */
+
+#ifdef __EMSCRIPTEN__
+EMSCRIPTEN_KEEPALIVE
+#endif
+int pico_get_button_a(void)     { return 1 << 6; }  /* GBTN_A */
+
+#ifdef __EMSCRIPTEN__
+EMSCRIPTEN_KEEPALIVE
+#endif
+int pico_get_button_start(void) { return 1 << 7; }  /* GBTN_START */
+
+#ifdef __EMSCRIPTEN__
+EMSCRIPTEN_KEEPALIVE
+#endif
+int pico_get_button_z(void)     { return 1 << 8; }  /* GBTN_Z */
+
+#ifdef __EMSCRIPTEN__
+EMSCRIPTEN_KEEPALIVE
+#endif
+int pico_get_button_y(void)     { return 1 << 9; }  /* GBTN_Y */
+
+#ifdef __EMSCRIPTEN__
+EMSCRIPTEN_KEEPALIVE
+#endif
+int pico_get_button_x(void)     { return 1 << 10; } /* GBTN_X */
+
+#ifdef __EMSCRIPTEN__
+EMSCRIPTEN_KEEPALIVE
+#endif
+int pico_get_button_mode(void)  { return 1 << 11; } /* GBTN_MODE */
+
+/* Region override API - values: 0=Auto, 1=Japan NTSC, 2=Japan PAL, 4=USA, 8=Europe */
+#ifdef __EMSCRIPTEN__
+EMSCRIPTEN_KEEPALIVE
+#endif
+void pico_set_region(int region)
+{
+    PicoIn.regionOverride = region;
+
+    /* If a game is loaded, re-detect region and reset */
+    if (game_loaded) {
+        PicoDetectRegion();
+        PicoLoopPrepare();
+        PsndRerate(0);
+    }
+}
+
+#ifdef __EMSCRIPTEN__
+EMSCRIPTEN_KEEPALIVE
+#endif
+int pico_get_region(void)
+{
+    /* Return current hardware region: 0x80=USA, 0xc0=Europe, 0x00=Japan NTSC, 0x40=Japan PAL */
+    return Pico.m.hardware & 0xc0;
+}
+
+/* Save state support - based on libretro implementation */
+/* 32X states need ~700KB+ (256KB SDRAM + 256KB DRAM + base Genesis state) */
+#define STATE_MAX_SIZE (2 * 1024 * 1024)  /* 2MB to safely handle 32X states */
+static unsigned char *state_buffer = NULL;
+static size_t state_size = 0;
+
+/* State file callbacks */
+struct state_context {
+    const unsigned char *load_buf;
+    unsigned char *save_buf;
+    size_t size;
+    size_t pos;
+};
+
+static size_t state_read_cb(void *p, size_t size, size_t nmemb, void *file)
+{
+    struct state_context *ctx = (struct state_context *)file;
+    size_t bsize = size * nmemb;
+
+    if (ctx->pos + bsize > ctx->size) {
+        bsize = ctx->size - ctx->pos;
+        if ((int)bsize <= 0)
+            return 0;
+    }
+
+    memcpy(p, ctx->load_buf + ctx->pos, bsize);
+    ctx->pos += bsize;
+    return bsize;
+}
+
+static size_t state_write_cb(void *p, size_t size, size_t nmemb, void *file)
+{
+    struct state_context *ctx = (struct state_context *)file;
+    size_t bsize = size * nmemb;
+
+    if (ctx->pos + bsize > ctx->size) {
+        bsize = ctx->size - ctx->pos;
+        if ((int)bsize <= 0)
+            return 0;
+    }
+
+    memcpy(ctx->save_buf + ctx->pos, p, bsize);
+    ctx->pos += bsize;
+    return bsize;
+}
+
+static size_t state_skip_cb(void *p, size_t size, size_t nmemb, void *file)
+{
+    struct state_context *ctx = (struct state_context *)file;
+    size_t bsize = size * nmemb;
+    ctx->pos += bsize;
+    return bsize;
+}
+
+static size_t state_eof_cb(void *file)
+{
+    struct state_context *ctx = (struct state_context *)file;
+    return ctx->pos >= ctx->size;
+}
+
+static int state_seek_cb(void *file, long offset, int whence)
+{
+    struct state_context *ctx = (struct state_context *)file;
+
+    switch (whence) {
+    case SEEK_SET:
+        ctx->pos = offset;
+        break;
+    case SEEK_CUR:
+        ctx->pos += offset;
+        break;
+    case SEEK_END:
+        ctx->pos = ctx->size + offset;
+        break;
+    }
+    return (int)ctx->pos;
+}
+
+#ifdef __EMSCRIPTEN__
+EMSCRIPTEN_KEEPALIVE
+#endif
+int pico_state_save(void)
+{
+    if (!game_loaded) {
+        return 0;
+    }
+
+    /* Allocate buffer if needed */
+    if (!state_buffer) {
+        state_buffer = (unsigned char *)malloc(STATE_MAX_SIZE);
+        if (!state_buffer) {
+            return 0;
+        }
+    }
+
+    struct state_context ctx = { 0 };
+    ctx.save_buf = state_buffer;
+    ctx.size = STATE_MAX_SIZE;
+    ctx.pos = 0;
+
+    int ret = PicoStateFP(&ctx, 1, NULL, state_write_cb, NULL, state_seek_cb);
+    if (ret != 0) {
+        return 0;
+    }
+
+    state_size = ctx.pos;
+    return 1;
+}
+
+/* Get pointer to state buffer (for JS to read after save) */
+#ifdef __EMSCRIPTEN__
+EMSCRIPTEN_KEEPALIVE
+#endif
+unsigned char *pico_get_state_buffer(void)
+{
+    return state_buffer;
+}
+
+/* Get size of saved state */
+#ifdef __EMSCRIPTEN__
+EMSCRIPTEN_KEEPALIVE
+#endif
+int pico_get_state_size(void)
+{
+    return (int)state_size;
+}
+
+/* Allocate/get buffer for loading state (JS writes data here before calling load) */
+#ifdef __EMSCRIPTEN__
+EMSCRIPTEN_KEEPALIVE
+#endif
+unsigned char *pico_get_state_load_buffer(int size)
+{
+    if (!state_buffer) {
+        state_buffer = (unsigned char *)malloc(STATE_MAX_SIZE);
+        if (!state_buffer) {
+            return NULL;
+        }
+    }
+    state_size = size;
+    return state_buffer;
+}
+
+#ifdef __EMSCRIPTEN__
+EMSCRIPTEN_KEEPALIVE
+#endif
+int pico_state_load(void)
+{
+    if (!game_loaded) {
+        return 0;
+    }
+
+    if (!state_buffer || state_size == 0) {
+        return 0;
+    }
+
+    struct state_context ctx = { 0 };
+    ctx.load_buf = state_buffer;
+    ctx.size = state_size;
+    ctx.pos = 0;
+
+    int ret = PicoStateFP(&ctx, 0, state_read_cb, NULL, state_eof_cb, state_seek_cb);
+    if (ret != 0) {
+        return 0;
+    }
+
+    return 1;
+}
+
+#ifdef __EMSCRIPTEN__
+EMSCRIPTEN_KEEPALIVE
+#endif
+int pico_state_exists(void)
+{
+    return (state_buffer != NULL && state_size > 0) ? 1 : 0;
+}
+
+/* Main entry point - called by Emscripten on startup */
+int main(int argc, char *argv[])
+{
+    pico_init();
+    return 0;
+}


### PR DESCRIPTION
I created this PR to add support for the Web platform. The Web build supports loading and saving game states and defaults to `asm.js` for better compatibility. However, WASM can still be enabled by passing `WASM=1` in the `Makefile.web` file. Lastly, due to how audio is handled, this implementation is free of the audio crackling common in many other web-based builds out there.

Tested with Sega Genesis and 32X ROMs on Chrome and Safari.

![1](https://github.com/user-attachments/assets/f04d2a66-23e2-4350-a9cb-0d603c5f9c68)

![2](https://github.com/user-attachments/assets/c55c6925-fbe2-4f10-af64-aebbaaeaef7a)

![3](https://github.com/user-attachments/assets/0b13bab9-a7a2-4126-89e9-06d53b3c2ff0)

Lastly, here is my own emulator wrapper using the `picodrive.js` file generated by this PR:

https://github.com/lrusso/Genesis
