### PR TITLE
fix: crash trying to use M68K RAM patching in SMS mode

### DIFF
--- a/platform/libretro/libretro.c
+++ b/platform/libretro/libretro.c
@@ -858,7 +858,7 @@ void retro_cheat_reset(void)
 		if (addr < Pico.romsize) {
 			if (PicoPatches[i].active)
 				*(unsigned short *)(Pico.rom + addr) = PicoPatches[i].data_old;
-		} else {
+		} else if (!(PicoIn.AHW & PAHW_SMS)) {
 			if (PicoPatches[i].active)
 				m68k_write16(PicoPatches[i].addr,PicoPatches[i].data_old);
 		}
@@ -909,7 +909,7 @@ void retro_cheat_set(unsigned index, bool enabled, const char *code)
 		PicoPatches[PicoPatchCount].comp = pt.comp;
 		if (PicoPatches[PicoPatchCount].addr < Pico.romsize)
 			PicoPatches[PicoPatchCount].data_old = *(uint16_t *)(Pico.rom + PicoPatches[PicoPatchCount].addr);
-		else
+		else if (!(PicoIn.AHW & PAHW_SMS))
 			PicoPatches[PicoPatchCount].data_old = (uint16_t) m68k_read16(PicoPatches[PicoPatchCount].addr);
 		PicoPatchCount++;
 


### PR DESCRIPTION
## Summary

Using Action Replay cheats for Sega Master System causes a SIGSEGV crash in picodrive core.

The issue is that Action Replay hardware patches RAM region, but picodrive only supports RAM patching (customary for Game Genie hardware).

## Changes

- add `!(PicoIn.AHW & PAHW_SMS)` guard so the M68K accessors are only reached when actually emulating a Genesis/Mega Drive
  - RAM patching for SMS is silently skipped, which is correct behavior — SMS uses a Z80, not an M68K, so those functions were never the right tool for SMS RAM patching.
  - The vast majority of SMS cheats in the libretro database are Action Replay format targeting RAM addresses, so all of them previously caused a crash.

Note that this change only fixes the crash.  Cheats still do not work, but they do not crash emulator process either.